### PR TITLE
fix: Wire up firestore reference in emulated environment.

### DIFF
--- a/src/firebase_functions/firestore_fn.py
+++ b/src/firebase_functions/firestore_fn.py
@@ -119,7 +119,8 @@ def _firestore_endpoint_handler(
     if _DEFAULT_APP_NAME not in _apps:
         initialize_app()
     app = get_app()
-    firestore_client = _firestore_v1.Client(project=app.project_id, database=event_database)
+    firestore_client = _firestore_v1.Client(project=app.project_id,
+                                            database=event_database)
     firestore_ref: DocumentReference = firestore_client.document(event_document)
     value_snapshot: DocumentSnapshot | None = None
     old_value_snapshot: DocumentSnapshot | None = None

--- a/src/firebase_functions/firestore_fn.py
+++ b/src/firebase_functions/firestore_fn.py
@@ -26,7 +26,7 @@ import firebase_functions.private.path_pattern as _path_pattern
 import firebase_functions.core as _core
 import cloudevents.http as _ce
 
-from firebase_admin import get_app, _apps, _DEFAULT_APP_NAME
+from firebase_admin import initialize_app, get_app, _apps, _DEFAULT_APP_NAME
 from google.cloud._helpers import _datetime_to_pb_timestamp
 from google.cloud.firestore_v1 import _helpers as _firestore_helpers
 

--- a/src/firebase_functions/firestore_fn.py
+++ b/src/firebase_functions/firestore_fn.py
@@ -26,6 +26,7 @@ import firebase_functions.private.path_pattern as _path_pattern
 import firebase_functions.core as _core
 import cloudevents.http as _ce
 
+from firebase_admin import get_app, _apps, _DEFAULT_APP_NAME
 from google.cloud._helpers import _datetime_to_pb_timestamp
 from google.cloud.firestore_v1 import _helpers as _firestore_helpers
 
@@ -115,7 +116,10 @@ def _firestore_endpoint_handler(
         "%Y-%m-%dT%H:%M:%S.%f%z",
     )
 
-    firestore_client = _firestore_v1.Client(database=event_database)
+    if _DEFAULT_APP_NAME not in _apps:
+        initialize_app()
+    app = get_app()
+    firestore_client = _firestore_v1.Client(project=app.project_id, database=event_database)
     firestore_ref: DocumentReference = firestore_client.document(event_document)
     value_snapshot: DocumentSnapshot | None = None
     old_value_snapshot: DocumentSnapshot | None = None


### PR DESCRIPTION
In the emulated environment, we must explicitly pass the project id for the Firestore Client per https://github.com/googleapis/python-firestore/blob/15872858332b56fefcb40fdfbc4df9320cd5ed75/google/cloud/firestore_v1/base_client.py#L133