### PR TITLE
refactor(db)!: reference is now instance of a Database reference

### DIFF
--- a/samples/basic_db/functions/main.py
+++ b/samples/basic_db/functions/main.py
@@ -12,18 +12,22 @@ options.set_global_options(region=options.SupportedRegion.EUROPE_WEST1)
 @db_fn.on_value_written(reference="hello/world")
 def onwriteexample(event: db_fn.Event[db_fn.Change]) -> None:
     print("Hello from db write event:", event)
+    print("Reference path:", event.reference.path)
 
 
 @db_fn.on_value_created(reference="hello/world")
 def oncreatedexample(event: db_fn.Event) -> None:
     print("Hello from db create event:", event)
+    print("Reference path:", event.reference.path)
 
 
 @db_fn.on_value_deleted(reference="hello/world")
 def ondeletedexample(event: db_fn.Event) -> None:
     print("Hello from db delete event:", event)
+    print("Reference path:", event.reference.path)
 
 
 @db_fn.on_value_updated(reference="hello/world")
 def onupdatedexample(event: db_fn.Event[db_fn.Change]) -> None:
     print("Hello from db updated event:", event)
+    print("Reference path:", event.reference.path)


### PR DESCRIPTION
Formerly a string only.

### Testing

Deployed the following function; 

```python
from firebase_functions import db_fn, options
from firebase_admin import initialize_app

initialize_app()

options.set_global_options(region=options.SupportedRegion.EUROPE_WEST1)


@db_fn.on_value_written(reference="hello/world", instance="a-non-default-database")
def onwriteexample(event: db_fn.Event[db_fn.Change]) -> None:
    print("Hello from db write event:", event)
    print("Reference.path:", event.reference.path)
    print("Reference.get():", event.reference.get())
```


Edited /hello/world on Firebase console to have the value `"some data in my hello/world ref woo!"`, this successfully triggered, logs shown below (note the none default database instance and non default region used in the deployed code to verify correct instance is targetted by the ref):

![image](https://user-images.githubusercontent.com/5347038/235984196-82b334e7-32ac-4527-96ae-907233b6b27a.png)

![image](https://user-images.githubusercontent.com/5347038/235984286-590e8b3d-90d7-4bd1-ade8-e24f78cdbb2a.png)

