### PR TITLE
fix(test_lab): client info details can be undefined (fixes #64)

### DIFF
--- a/src/firebase_functions/test_lab_fn.py
+++ b/src/firebase_functions/test_lab_fn.py
@@ -222,7 +222,7 @@ def _event_handler(func: _C1, raw: _ce.CloudEvent) -> None:
         ),
         client_info=ClientInfo(
             client=event_data["clientInfo"]["client"],
-            details=event_data["clientInfo"]["details"],
+            details=event_data["clientInfo"].get("details", {}),
         ),
         test_matrix_id=event_data["testMatrixId"],
     )

--- a/tests/test_test_lab_fn.py
+++ b/tests/test_test_lab_fn.py
@@ -78,9 +78,6 @@ class TestTestLab(unittest.TestCase):
                 },
                 "clientInfo": {
                     "client": "gcloud",
-                    "details": {
-                        "someKey": "someValue",
-                    },
                 },
                 "testMatrixId": "testmatrix-123",
             })


### PR DESCRIPTION
Client Info details can be optional in some scenarios, this now defaults to empty dict if the key does not exist.

Fixes #64 