### PR TITLE
fix: normalize firestore document path

### DIFF
--- a/src/firebase_functions/firestore_fn.py
+++ b/src/firebase_functions/firestore_fn.py
@@ -201,8 +201,9 @@ def on_document_written(**kwargs) -> _typing.Callable[[_C1], _C1]:
     options = FirestoreOptions(**kwargs)
 
     def on_document_written_inner_decorator(func: _C1):
-        document_pattern = _path_pattern.PathPattern(options.document)
-
+        print("WWWWWWWWWW: ", options.document)
+        document_pattern = _path_pattern.PathPattern(_util.normalize_path(options.document))
+        print("WWWWWWWWWW 1111111: ", _util.normalize_path(options.document))
         @_functools.wraps(func)
         def on_document_written_wrapped(raw: _ce.CloudEvent):
             return _firestore_endpoint_handler(
@@ -248,7 +249,7 @@ def on_document_updated(**kwargs) -> _typing.Callable[[_C1], _C1]:
     options = FirestoreOptions(**kwargs)
 
     def on_document_updated_inner_decorator(func: _C1):
-        document_pattern = _path_pattern.PathPattern(options.document)
+        document_pattern = _path_pattern.PathPattern(_util.normalize_path(options.document))
 
         @_functools.wraps(func)
         def on_document_updated_wrapped(raw: _ce.CloudEvent):
@@ -295,7 +296,7 @@ def on_document_created(**kwargs) -> _typing.Callable[[_C2], _C2]:
     options = FirestoreOptions(**kwargs)
 
     def on_document_created_inner_decorator(func: _C2):
-        document_pattern = _path_pattern.PathPattern(options.document)
+        document_pattern = _path_pattern.PathPattern(_util.normalize_path(options.document))
 
         @_functools.wraps(func)
         def on_document_created_wrapped(raw: _ce.CloudEvent):
@@ -342,7 +343,7 @@ def on_document_deleted(**kwargs) -> _typing.Callable[[_C2], _C2]:
     options = FirestoreOptions(**kwargs)
 
     def on_document_deleted_inner_decorator(func: _C2):
-        document_pattern = _path_pattern.PathPattern(options.document)
+        document_pattern = _path_pattern.PathPattern(_util.normalize_path(options.document))
 
         @_functools.wraps(func)
         def on_document_deleted_wrapped(raw: _ce.CloudEvent):

--- a/src/firebase_functions/firestore_fn.py
+++ b/src/firebase_functions/firestore_fn.py
@@ -201,7 +201,8 @@ def on_document_written(**kwargs) -> _typing.Callable[[_C1], _C1]:
     options = FirestoreOptions(**kwargs)
 
     def on_document_written_inner_decorator(func: _C1):
-        document_pattern = _path_pattern.PathPattern(_util.normalize_path(options.document))
+        document_pattern = _path_pattern.PathPattern(
+            _util.normalize_path(options.document))
 
         @_functools.wraps(func)
         def on_document_written_wrapped(raw: _ce.CloudEvent):
@@ -248,7 +249,8 @@ def on_document_updated(**kwargs) -> _typing.Callable[[_C1], _C1]:
     options = FirestoreOptions(**kwargs)
 
     def on_document_updated_inner_decorator(func: _C1):
-        document_pattern = _path_pattern.PathPattern(_util.normalize_path(options.document))
+        document_pattern = _path_pattern.PathPattern(
+            _util.normalize_path(options.document))
 
         @_functools.wraps(func)
         def on_document_updated_wrapped(raw: _ce.CloudEvent):
@@ -295,7 +297,8 @@ def on_document_created(**kwargs) -> _typing.Callable[[_C2], _C2]:
     options = FirestoreOptions(**kwargs)
 
     def on_document_created_inner_decorator(func: _C2):
-        document_pattern = _path_pattern.PathPattern(_util.normalize_path(options.document))
+        document_pattern = _path_pattern.PathPattern(
+            _util.normalize_path(options.document))
 
         @_functools.wraps(func)
         def on_document_created_wrapped(raw: _ce.CloudEvent):
@@ -342,7 +345,8 @@ def on_document_deleted(**kwargs) -> _typing.Callable[[_C2], _C2]:
     options = FirestoreOptions(**kwargs)
 
     def on_document_deleted_inner_decorator(func: _C2):
-        document_pattern = _path_pattern.PathPattern(_util.normalize_path(options.document))
+        document_pattern = _path_pattern.PathPattern(
+            _util.normalize_path(options.document))
 
         @_functools.wraps(func)
         def on_document_deleted_wrapped(raw: _ce.CloudEvent):

--- a/src/firebase_functions/firestore_fn.py
+++ b/src/firebase_functions/firestore_fn.py
@@ -201,9 +201,8 @@ def on_document_written(**kwargs) -> _typing.Callable[[_C1], _C1]:
     options = FirestoreOptions(**kwargs)
 
     def on_document_written_inner_decorator(func: _C1):
-        print("WWWWWWWWWW: ", options.document)
         document_pattern = _path_pattern.PathPattern(_util.normalize_path(options.document))
-        print("WWWWWWWWWW 1111111: ", _util.normalize_path(options.document))
+
         @_functools.wraps(func)
         def on_document_written_wrapped(raw: _ce.CloudEvent):
             return _firestore_endpoint_handler(

--- a/src/firebase_functions/private/util.py
+++ b/src/firebase_functions/private/util.py
@@ -308,3 +308,9 @@ def firebase_config() -> None | FirebaseConfig:
             f'FIREBASE_CONFIG JSON string "{json_str}" is not valid json. {err}'
         ) from err
     return FirebaseConfig(storage_bucket=json_data.get("storageBucket"))
+
+def normalize_path(path: str) -> str:
+    """
+    Normalize a path string to a consistent format.
+    """
+    return path.strip("/")

--- a/src/firebase_functions/private/util.py
+++ b/src/firebase_functions/private/util.py
@@ -309,6 +309,7 @@ def firebase_config() -> None | FirebaseConfig:
         ) from err
     return FirebaseConfig(storage_bucket=json_data.get("storageBucket"))
 
+
 def normalize_path(path: str) -> str:
     """
     Normalize a path string to a consistent format.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -15,7 +15,7 @@
 Internal utils tests.
 """
 from os import environ, path
-from firebase_functions.private.util import firebase_config
+from firebase_functions.private.util import firebase_config, normalize_path
 
 test_bucket = "python-functions-testing.appspot.com"
 test_config_file = path.join(path.dirname(path.realpath(__file__)),
@@ -40,3 +40,21 @@ def test_firebase_config_loads_from_env_file():
     environ["FIREBASE_CONFIG"] = test_config_file
     assert firebase_config().storage_bucket == test_bucket, (
         "Failure, firebase_config did not load from env variable.")
+
+
+def test_normalize_document_path():
+    """
+    Testing "document" path passed to Firestore event listener 
+    is normalized.
+    """
+    test_path = "/test/document/"
+    assert normalize_path(test_path) == "test/document", (
+        "Failure, path was not normalized.")
+
+    test_path1 = "//////test/document//////////"
+    assert normalize_path(test_path1) == "test/document", (
+        "Failure, path was not normalized.")
+
+    test_path2 = "test/document"
+    assert normalize_path(test_path2) == "test/document", (
+        "Failure, path should not be changed if it is already normalized.")


### PR DESCRIPTION
This PR should be merged first to fix the formatting CI failure: https://github.com/firebase/firebase-functions-python/pull/108

Created a util function for normalizing Firestore document paths for each Firestore event listener.

fix #91 

We tested the implementation by running Functions emulator. Here is a sample log of the path coming into the function before and after the path is normalized:

Print logs to show before and after we normalize the path:
<img width="813" alt="Screenshot 2023-06-19 at 13 49 08" src="https://github.com/firebase/firebase-functions-python/assets/16018629/85c083f2-f2ff-447f-9d4e-169d065a9fa4">

Output on the console for "created", "written", "updated" & "deleted":
<img width="897" alt="Screenshot 2023-06-19 at 14 19 46" src="https://github.com/firebase/firebase-functions-python/assets/16018629/fc760f06-84ab-4df0-a0e1-e59f0d5a47b0">


We've also created a unit test for the normalize function [here](https://github.com/firebase/firebase-functions-python/pull/106/files#diff-0dcbadaa6c70afb6fea041dec04bb89c3cc7fe201fb7c3185a669efa49769f28R45-R60)
