### PR TITLE
SupportedRegion as a StrEnum

### DIFF
--- a/src/firebase_functions/options.py
+++ b/src/firebase_functions/options.py
@@ -89,7 +89,7 @@ class MemoryOption(int, _enum.Enum):
     GB_32 = 32 << 10
 
 
-class SupportedRegion(str, _enum.Enum):
+class SupportedRegion(_enum.StrEnum):
     """
     All regions supported by Cloud Functions (2nd gen).
     """

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -217,3 +217,11 @@ def test_merge_apis_duplicate_apis():
     for actual_item in merged_apis:
         assert (actual_item in expected_output
                ), f"Unexpected item {actual_item} found in the merged list"
+
+def test_supported_region_enum_uses_str_representation():
+    """
+    Test SupportedRegion enum values are converted to their
+    string values for representation.
+    """
+    assert options.SupportedRegion.US_CENTRAL1 == "us-central1"
+    assert f"{options.SupportedRegion.US_CENTRAL1}" == "us-central1"


### PR DESCRIPTION
SupportedRegion should be a StrEnum so that `__str__` works as expected, e.g. in

https://github.com/firebase/functions-samples/blob/main/Python/taskqueues-backup-images/functions/main.py#L144-L168