### PR TITLE
fix: handle leading forward slash in pattern matching path function

### DIFF
--- a/src/firebase_functions/private/path_pattern.py
+++ b/src/firebase_functions/private/path_pattern.py
@@ -166,7 +166,8 @@ class PathPattern:
     def extract_matches(self, path: str) -> dict[str, str]:
         segments = self.segments
         if self.segments[0].value == "":
-            # if leading slash, there will be an empty segment which increases the path index, we pop to remove it
+            # if leading slash, there will be an empty segment which increases 
+            # the path index, we pop to remove it
             segments.pop(0)
         matches: dict[str, str] = {}
         if not self.has_captures:

--- a/src/firebase_functions/private/path_pattern.py
+++ b/src/firebase_functions/private/path_pattern.py
@@ -129,9 +129,10 @@ class PathPattern:
     segments: list[PathSegment]
 
     def __init__(self, raw_path: str):
-        self.raw = raw_path
+        normalized_path = raw_path.strip("/")
+        self.raw = normalized_path
         self.segments = []
-        self.init_path_segments(raw_path)
+        self.init_path_segments(normalized_path)
 
     def init_path_segments(self, raw: str):
         parts = raw.split("/")
@@ -164,19 +165,14 @@ class PathPattern:
                    for segment in self.segments)
 
     def extract_matches(self, path: str) -> dict[str, str]:
-        segments = self.segments
-        if self.segments[0].value == "":
-            # if leading slash, there will be an empty segment which increases
-            # the path index, we pop to remove it
-            segments.pop(0)
         matches: dict[str, str] = {}
         if not self.has_captures:
             return matches
         path_segments = path_parts(path)
         path_ndx = 0
-        for segment_ndx in range(len(segments)):
-            segment = segments[segment_ndx]
-            remaining_segments = len(segments) - 1 - segment_ndx
+        for segment_ndx in range(len(self.segments)):
+            segment = self.segments[segment_ndx]
+            remaining_segments = len(self.segments) - 1 - segment_ndx
             next_path_ndx = len(path_segments) - remaining_segments
             if segment.name == SegmentName.SINGLE_CAPTURE:
                 matches[segment.trimmed] = path_segments[path_ndx]

--- a/src/firebase_functions/private/path_pattern.py
+++ b/src/firebase_functions/private/path_pattern.py
@@ -164,14 +164,18 @@ class PathPattern:
                    for segment in self.segments)
 
     def extract_matches(self, path: str) -> dict[str, str]:
+        segments = self.segments
+        if self.segments[0].value == "":
+            # if leading slash, there will be an empty segment which increases the path index, we pop to remove it
+            segments.pop(0)
         matches: dict[str, str] = {}
         if not self.has_captures:
             return matches
         path_segments = path_parts(path)
         path_ndx = 0
-        for segment_ndx in range(len(self.segments)):
-            segment = self.segments[segment_ndx]
-            remaining_segments = len(self.segments) - 1 - segment_ndx
+        for segment_ndx in range(len(segments)):
+            segment = segments[segment_ndx]
+            remaining_segments = len(segments) - 1 - segment_ndx
             next_path_ndx = len(path_segments) - remaining_segments
             if segment.name == SegmentName.SINGLE_CAPTURE:
                 matches[segment.trimmed] = path_segments[path_ndx]

--- a/src/firebase_functions/private/path_pattern.py
+++ b/src/firebase_functions/private/path_pattern.py
@@ -166,7 +166,7 @@ class PathPattern:
     def extract_matches(self, path: str) -> dict[str, str]:
         segments = self.segments
         if self.segments[0].value == "":
-            # if leading slash, there will be an empty segment which increases 
+            # if leading slash, there will be an empty segment which increases
             # the path index, we pop to remove it
             segments.pop(0)
         matches: dict[str, str] = {}

--- a/tests/test_path_pattern.py
+++ b/tests/test_path_pattern.py
@@ -41,6 +41,28 @@ class TestPathPattern(TestCase):
         self.assertEqual(trim_param("{something=*}"), "something")
 
     def test_extract_matches(self):
+        # parse single-capture segments with leading slash
+        pp = PathPattern("/messages/{a}/{b}/{c}")
+        self.assertEqual(
+            pp.extract_matches("messages/match_a/match_b/match_c"),
+            {
+                "a": "match_a",
+                "b": "match_b",
+                "c": "match_c",
+            },
+        )
+
+        # parse single-capture segments without leading slash
+        pp = PathPattern("messages/{a}/{b}/{c}")
+        self.assertEqual(
+            pp.extract_matches("messages/match_a/match_b/match_c"),
+            {
+                "a": "match_a",
+                "b": "match_b",
+                "c": "match_c",
+            },
+        )
+
         # parse without multi-capture segments
         pp = PathPattern("{a}/something/else/{b}/end/{c}")
         self.assertEqual(


### PR DESCRIPTION
A leading forward slash will add an additional segment when extracting pattern matching elements causing an out of range index error.

fixes https://github.com/firebase/firebase-functions-python/issues/113