### PR TITLE
fix: issue with logging

### DIFF
--- a/src/firebase_functions/private/util.py
+++ b/src/firebase_functions/private/util.py
@@ -114,7 +114,7 @@ def _on_call_valid_body(request: _Request) -> bool:
         return False
 
     # The body must have data.
-    if request.json is None or "data" not in request.json:
+    if "data" not in request.json:
         _logging.warning("Request body is missing data.", request.json)
         return False
 

--- a/src/firebase_functions/private/util.py
+++ b/src/firebase_functions/private/util.py
@@ -143,7 +143,7 @@ def _on_call_valid_content_type(request: _Request) -> bool:
     content_type: str | None = request.headers.get("Content-Type")
 
     if content_type is None:
-        _logging.warning("Request is missing Content-Type.", content_type)
+        _logging.warning("Request is missing Content-Type.")
         return False
 
     # If it has a charset, just ignore it for now.


### PR DESCRIPTION
# Summary
I removed an invalid argument to a logging.warning call.

## Related
https://github.com/firebase/firebase-functions-python/issues/130

# What was broken
As-is, the logging block for missing content-type headers is:
```py
def _on_call_valid_content_type(request: _Request) -> bool:
    """Validate content"""
    content_type: str | None = request.headers.get("Content-Type")

    if content_type is None:
        _logging.warning("Request is missing Content-Type.", content_type)
        return False
...
```
In the conditional block, you can see the None positional arg `content_type` passed to the logging call. Python logging doesn't allow null positional (nor keyword) args. The logging used in this module is indeed stdlib Python logging cf [functions-framework-python](https://github.com/GoogleCloudPlatform/functions-framework-python/blob/main/src/functions_framework/__init__.py) from which it is imported.

## A minimal reproducible example
Using Python 3.11.4, `python -c 'import logging; logging.warning("this will raise an exception", None)'`

### Expected result
```
--- Logging error ---
Traceback (most recent call last):
  File "/.../3.11.4/lib/python3.11/logging/__init__.py", line 1110, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/.../3.11.4/lib/python3.11/logging/__init__.py", line 953, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/...versions/3.11.4/lib/python3.11/logging/__init__.py", line 687, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/.../python3.11/logging/__init__.py", line 377, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "<string>", line 1, in <module>
Message: 'this will raise an exception'
Arguments: (None,)
```