### PR TITLE
fix the most egregious issue with the use of python logging

### DIFF
--- a/src/firebase_functions/private/util.py
+++ b/src/firebase_functions/private/util.py
@@ -133,7 +133,7 @@ def _on_call_valid_body(request: _Request) -> bool:
 def _on_call_valid_method(request: _Request) -> bool:
     """Make sure it's a POST."""
     if request.method != "POST":
-        _logging.warning("Request has invalid method.", request.method)
+        _logging.warning("Request has invalid method. %s", request.method)
         return False
     return True
 


### PR DESCRIPTION
From the [Python 3.11 docs](), emphasis added:
"""
debug(msg, *args, **kwargs)

Logs a message with level [DEBUG](https://docs.python.org/3/library/logging.html#logging.DEBUG) on this logger. The msg is the _message format string, and the args are the arguments which are merged into msg using the string formatting operator_. (Note that this means that you can use keywords in the format string, together with a single dictionary argument.) _No % formatting operation is performed on msg when no args are supplied_.
"""

The simplest reproducible error case is: `python -c 'import logging; logging.warning("asdf", "qwer");'`
The expected result is a stack trace.

To fix: `logger.warning("asdf %s", "qwer");`

Please note that the firebase-functions-python codebase has a tremendous number of instances of this logging usage error. I'm only fixing the one that I encounter most frequently here, but it might be useful to perform a systematic review of the logging usage throughout the package.