### PR TITLE
fix: Crash in auth blocking function when using with phone auth

### DIFF
--- a/src/firebase_functions/private/_identity_fn.py
+++ b/src/firebase_functions/private/_identity_fn.py
@@ -111,7 +111,7 @@ def _auth_user_record_from_token_data(token_data: dict[str, _typing.Any]):
     return AuthUserRecord(
         uid=token_data["uid"],
         email=token_data.get("email"),
-        email_verified=token_data["email_verified"],
+        email_verified=token_data.get("email_verified"),
         display_name=token_data.get("display_name"),
         photo_url=token_data.get("photo_url"),
         phone_number=token_data.get("phone_number"),


### PR DESCRIPTION
When using blocking function for phone auth, it crashes, because the dict does not seem to include "email_verified" param.