### PR TITLE
chore: update release workflow to publish PyPI package as a Trusted Publisher

### DIFF
--- a/.github/scripts/publish_preflight_check.sh
+++ b/.github/scripts/publish_preflight_check.sh
@@ -138,19 +138,19 @@ echo_info "---< git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true >---
 git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
 echo ""
 
-readonly EXISTING_TAG=`git rev-parse -q --verify "refs/tags/v${RELEASE_VERSION}"` || true
+readonly EXISTING_TAG=`git rev-parse -q --verify "refs/tags/${RELEASE_VERSION}"` || true
 if [[ -n "${EXISTING_TAG}" ]]; then
-  echo_warn "Tag v${RELEASE_VERSION} already exists. Exiting."
+  echo_warn "Tag ${RELEASE_VERSION} already exists. Exiting."
   echo_warn "If the tag was created in a previous unsuccessful attempt, delete it and try again."
-  echo_warn "  $ git tag -d v${RELEASE_VERSION}"
-  echo_warn "  $ git push --delete origin v${RELEASE_VERSION}"
+  echo_warn "  $ git tag -d ${RELEASE_VERSION}"
+  echo_warn "  $ git push --delete origin ${RELEASE_VERSION}"
 
-  readonly RELEASE_URL="https://github.com/firebase/firebase-functions-python/releases/tag/v${RELEASE_VERSION}"
+  readonly RELEASE_URL="https://github.com/firebase/firebase-functions-python/releases/tag/${RELEASE_VERSION}"
   echo_warn "Delete any corresponding releases at ${RELEASE_URL}."
   terminate
 fi
 
-echo_info "Tag v${RELEASE_VERSION} does not exist."
+echo_info "Tag ${RELEASE_VERSION} does not exist."
 
 
 echo_info ""

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,9 +80,16 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      # Used to create a short-lived OIDC token which is given to PyPi to identify this workflow job
+      # See: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+      # and https://docs.pypi.org/trusted-publishers/using-a-publisher/
+      id-token: write
+      contents: write
+
     steps:
     - name: Checkout source for publish
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Download the artifacts created by the stage_release job.
     - name: Download release candidates
@@ -113,6 +120,3 @@ jobs:
 
     - name: Publish to Pypi
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: firebase
-        password: ${{ secrets.PYPI_PASSWORD }}

--- a/src/firebase_functions/__init__.py
+++ b/src/firebase_functions/__init__.py
@@ -15,4 +15,4 @@
 Firebase Functions for Python.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
Starting in 2024, PyPI requires all users to enable Two-Factor Authentication. This will consequently require all users to switch to either Trusted Publishers (preferred) or API tokens for package uploads. Read more: https://blog.pypi.org/posts/2023-05-25-securing-pypi-with-2fa/

Trusted Publishers allows publishing packages to PyPI from automated environments like GitHub Actions without needing to use username/password combinations or API tokens to authenticate with PyPI. Read more: https://docs.pypi.org/trusted-publishers

This PR updates our release workflow to enable publishing to PyPI from the GitHub Actions automated environment.