### PR TITLE
Revert "chore: Release 0.3.0 (#189)"

### DIFF
--- a/src/firebase_functions/__init__.py
+++ b/src/firebase_functions/__init__.py
@@ -15,4 +15,4 @@
 Firebase Functions for Python.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
Starting in 2024, PyPI has made changes that require adding GitHub Actions as a Trusted Publisher in order to publish packages via our GitHub release workflow. This reverts the PR that triggered the broken release so that we can make the necessary changes to our release workflow and publish to PyPI as a Trusted Publisher (see https://github.com/firebase/firebase-functions-python/pull/190).

This reverts commit ee9589d1a5ebe5e2f8e79755b86ec0c3d8efb589.