### PR TITLE
chore: Release 0.3.0

### DIFF
--- a/src/firebase_functions/__init__.py
+++ b/src/firebase_functions/__init__.py
@@ -15,4 +15,4 @@
 Firebase Functions for Python.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
https://github.com/firebase/firebase-functions-python/pull/189 failed due to a change to PyPI's publishing policy. We reverted the PR and deleted the corresponding 0.3.0 release and tag, so this is take 2. See https://github.com/firebase/firebase-functions-python/pull/190 for the release workflow modifications.