### PR TITLE
make non-ascii characters in logger messages legible

### DIFF
--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -44,9 +44,8 @@ def _entry_from_args(severity: LogSeverity, *args, **kwargs) -> LogEntry:
     """
 
     message: str = " ".join([
-        value
-        if isinstance(value, str) else _json.dumps(_remove_circular(value))
-        for value in args
+        value if isinstance(value, str) else _json.dumps(
+            _remove_circular(value), ensure_ascii=False) for value in args
     ])
 
     other: _typing.Dict[str, _typing.Any] = {
@@ -95,7 +94,8 @@ def _get_write_file(severity: LogSeverity) -> _typing.TextIO:
 
 def write(entry: LogEntry) -> None:
     write_file = _get_write_file(entry["severity"])
-    print(_json.dumps(_remove_circular(entry)), file=write_file)
+    print(_json.dumps(_remove_circular(entry), ensure_ascii=False),
+          file=write_file)
 
 
 def debug(*args, **kwargs) -> None:


### PR DESCRIPTION
Currently, logger messages containing non-ascii characters are displayed as unicode escape sequences, making them illegible to anyone reading the logs.

For example,
```python
from firebase_functions import logger
logger.log("こんにちは")
# outputs: {"severity": "NOTICE", "message": "\u3053\u3093\u306b\u3061\u306f"}
```

This behavior is due to the logger module making use of `json.dumps` which by default only outputs ascii characters (see [here](https://docs.python.org/3/library/json.html#json.dumps)).

I added `ensure_ascii=False` to wherever `json.dumps` was used for the logger messages and now output for these logs should be legible.
```python
logger.log("こんにちは")
# outputs: {"severity": "NOTICE", "message": "こんにちは"}
```

Let me know if there are any questions or issues 👍

