### PR TITLE
fix: invoker length assertion

### DIFF
--- a/src/firebase_functions/options.py
+++ b/src/firebase_functions/options.py
@@ -1134,7 +1134,7 @@ class HttpsOptions(RuntimeOptions):
                     invoker = [invoker]
                 assert len(
                     invoker
-                ) > 1, "HttpsOptions: Invalid option for invoker - must be a non-empty list."
+                ) >= 1, "HttpsOptions: Invalid option for invoker - must be a non-empty list."
                 assert "" not in invoker, (
                     "HttpsOptions: Invalid option for invoker - must be a non-empty string."
                 )


### PR DESCRIPTION
When `len(invoker) == 1`, like how it's being set in the line right before the assertion, it will fail.