### PR TITLE
fix: FloatParam marked private as unsupported in CLI

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -147,6 +147,7 @@ disable=abstract-method,
         xrange-builtin,
         zip-builtin-not-iterating,
         import-outside-toplevel,
+        protected-access,
 
 
 [REPORTS]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import find_packages, setup
 install_requires = [
     'flask>=2.1.2', 'functions-framework>=3.0.0', 'firebase-admin>=6.0.0',
     'pyyaml>=6.0', 'typing-extensions>=4.4.0', 'cloudevents==1.9.0',
-    'flask-cors>=3.0.10', 'pyjwt[crypto]>=2.5.0', 'google-events>=0.5.0',
+    'flask-cors>=3.0.10', 'pyjwt[crypto]>=2.5.0', 'google-events==0.5.0',
     'google-cloud-firestore>=2.11.0'
 ]
 

--- a/src/firebase_functions/params.py
+++ b/src/firebase_functions/params.py
@@ -344,8 +344,12 @@ class IntParam(Param[int]):
 
 
 @_dataclasses.dataclass(frozen=True)
-class FloatParam(Param[float]):
-    """A parameter as a float value."""
+class _FloatParam(Param[float]):
+    """
+    A parameter as a float value.
+    Marked as private because it is not supported by firebase-tools yet.
+    Unmark when it is supported.
+    """
 
     @property
     def value(self) -> float:

--- a/src/firebase_functions/private/manifest.py
+++ b/src/firebase_functions/private/manifest.py
@@ -241,7 +241,7 @@ def _param_to_spec(
         spec_dict["type"] = "boolean"
     elif isinstance(param, _params.IntParam):
         spec_dict["type"] = "int"
-    elif isinstance(param, _params.FloatParam):
+    elif isinstance(param, _params._FloatParam):
         spec_dict["type"] = "float"
     elif isinstance(param, _params.SecretParam):
         spec_dict["type"] = "secret"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -65,7 +65,7 @@ full_stack = _manifest.ManifestStack(
     params=[
         _params.BoolParam("BOOL_TEST", default=False),
         _params.IntParam("INT_TEST", description="int_description"),
-        _params.FloatParam("FLOAT_TEST", immutable=True),
+        _params._FloatParam("FLOAT_TEST", immutable=True),
         _params.SecretParam("SECRET_TEST"),
         _params.StringParam("STRING_TEST"),
         _params.ListParam("LIST_TEST", default=["1", "2", "3"]),

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -58,28 +58,28 @@ class TestFloatParams:
     def test_float_param_value(self):
         """Testing if float params correctly returns a value."""
         environ["FLOAT_VALUE_TEST"] = "123.456"
-        assert params.FloatParam("FLOAT_VALUE_TEST",).value == 123.456, \
+        assert params._FloatParam("FLOAT_VALUE_TEST",).value == 123.456, \
             "Failure, params value != 123.456"
 
     def test_float_param_empty_default(self):
         """Testing if float params defaults to empty float if no value and no default."""
-        assert params.FloatParam("FLOAT_DEFAULT_TEST1").value == float(), \
+        assert params._FloatParam("FLOAT_DEFAULT_TEST1").value == float(), \
             "Failure, params value is not float"
 
     def test_float_param_default(self):
         """Testing if float param defaults to provided default value."""
-        assert params.FloatParam("FLOAT_DEFAULT_TEST2",
+        assert params._FloatParam("FLOAT_DEFAULT_TEST2", \
         default=float(456.789)).value == 456.789, \
             "Failure, params default value != 456.789"
 
     def test_float_param_equality(self):
         """Test float equality."""
-        assert (params.FloatParam("FLOAT_TEST1",
-                                  default=123.456).equals(123.456).value
-                is True), "Failure, equality check returned False"
-        assert (params.FloatParam("FLOAT_TEST2",
-                                  default=456.789).equals(123.456).value
-                is False), "Failure, equality check returned False"
+        assert (params._FloatParam("FLOAT_TEST1", \
+        default=123.456).equals(123.456).value \
+            is True), "Failure, equality check returned False"
+        assert (params._FloatParam("FLOAT_TEST2", \
+        default=456.789).equals(123.456).value \
+            is False), "Failure, equality check returned False"
 
 
 class TestIntParams:


### PR DESCRIPTION
To resolve [this issue](https://github.com/firebase/firebase-functions-python/issues/209)

Note: changing `google-events>=0.5.0` to `google-events==0.5.0` is due to breaking changes in a later version (than 0.5.0) of `google-events` causing linting to fail. Failure can be seen [here](https://github.com/firebase/firebase-functions-python/actions/runs/12119305084/job/33785597146).