### PR TITLE
fix(logger): set utf-8 encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import find_packages, setup
 install_requires = [
     'flask>=2.1.2', 'functions-framework>=3.0.0', 'firebase-admin>=6.0.0',
     'pyyaml>=6.0', 'typing-extensions>=4.4.0', 'cloudevents==1.9.0',
-    'flask-cors>=3.0.10', 'pyjwt[crypto]>=2.5.0', 'google-events>=0.5.0',
+    'flask-cors>=3.0.10', 'pyjwt[crypto]>=2.5.0', 'google-events==0.5.0',
     'google-cloud-firestore>=2.11.0'
 ]
 

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -8,6 +8,12 @@ import sys as _sys
 import typing as _typing
 import typing_extensions as _typing_extensions
 
+# If encoding is not 'utf-8', change it to 'utf-8'.
+if _sys.stdout.encoding != "utf-8":
+    _sys.stdout.reconfigure(encoding="utf-8")  # type: ignore
+if _sys.stderr.encoding != "utf-8":
+    _sys.stderr.reconfigure(encoding="utf-8")  # type: ignore
+
 
 class LogSeverity(str, _enum.Enum):
     """


### PR DESCRIPTION
Resolves #226 

Note: changing `google-events>=0.5.0` to `google-events==0.5.0` is due to breaking changes in a later version (than 0.5.0) of `google-events` causing linting to fail. Failure can be seen [here](https://github.com/firebase/firebase-functions-python/actions/runs/12363926530/job/34506216421).