### PR TITLE
Upping the  dependency to cloudevents>=1.2.0,<2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     'flask>=2.1.2', 'functions-framework>=3.0.0', 'firebase-admin>=6.0.0',
-    'pyyaml>=6.0', 'typing-extensions>=4.4.0', 'cloudevents==1.9.0',
+    'pyyaml>=6.0', 'typing-extensions>=4.4.0', 'cloudevents>=1.2.0,<2.0.0',
     'flask-cors>=3.0.10', 'pyjwt[crypto]>=2.5.0', 'google-events==0.5.0',
     'google-cloud-firestore>=2.11.0'
 ]


### PR DESCRIPTION
Resolves #234.

Upping the dependency to `cloudevents>=1.2.0,<2.0.0`.  
Same as `functions-framework` [(source) setup.py](https://github.com/GoogleCloudPlatform/functions-framework-python/blob/main/setup.py)