### PR TITLE
chore: Release 0.4.3 (take 2)

### DIFF
--- a/src/firebase_functions/__init__.py
+++ b/src/firebase_functions/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Google Inc.
+# Copyright 2025 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
The previous PR that was merged had a small typo that didn't end up triggering the release GitHub action.