### PR TITLE
fix: fix pyproject.toml to include all packages.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,30 +6,30 @@ build-backend = "setuptools.build_meta"
 name = "firebase_functions"
 description = "Firebase Functions Python SDK"
 readme = "README.md"
-license = {text = "Apache-2.0"}
-authors = [
-    {name = "Firebase Team"}
-]
+license = "Apache-2.0"
+authors = [{ name = "Firebase Team" }]
 keywords = ["firebase", "functions", "google", "cloud"]
 classifiers = [
-    "Development Status :: 4 - Beta",
-    "Intended Audience :: Developers",
-    "Topic :: Software Development :: Build Tools",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Topic :: Software Development :: Build Tools",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "flask>=2.1.2",
-    "functions-framework>=3.0.0",
-    "firebase-admin>=6.0.0",
-    "pyyaml>=6.0",
-    "typing-extensions>=4.4.0",
-    "cloudevents>=1.2.0,<2.0.0",
-    "flask-cors>=3.0.10",
-    "pyjwt[crypto]>=2.5.0",
-    "google-events==0.5.0",
-    "google-cloud-firestore>=2.11.0",
+  "flask>=2.1.2",
+  "functions-framework>=3.0.0",
+  "firebase-admin>=6.0.0",
+  "pyyaml>=6.0",
+  "typing-extensions>=4.4.0",
+  "cloudevents>=1.2.0,<2.0.0",
+  "flask-cors>=3.0.10",
+  "pyjwt[crypto]>=2.5.0",
+  "google-events==0.5.0",
+  "google-cloud-firestore>=2.11.0",
 ]
 dynamic = ["version"]
 
@@ -41,43 +41,38 @@ dynamic = ["version"]
 
 [dependency-groups]
 dev = [
-    "pytest>=7.1.2,<9",
-    "setuptools>=63.4.2",
-    "pytest-cov>=3.0.0",
-    "mypy>=1.0.0",
-    "sphinx>=6.1.3",
-    "sphinxcontrib-napoleon>=0.7",
-    "toml>=0.10.2",
-    "google-cloud-tasks>=2.13.1",
-    "ruff>=0.1.0",
-    "build>=1.0.0",
+  "pytest>=7.1.2,<9",
+  "setuptools>=63.4.2",
+  "pytest-cov>=3.0.0",
+  "mypy>=1.0.0",
+  "sphinx>=6.1.3",
+  "sphinxcontrib-napoleon>=0.7",
+  "toml>=0.10.2",
+  "google-cloud-tasks>=2.13.1",
+  "ruff>=0.1.0",
+  "build>=1.0.0",
 ]
 
 [tool.setuptools]
-package-dir = {"" = "src"}
-packages = ["firebase_functions"]
+package-dir = { "" = "src" }
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [tool.setuptools.package-data]
 firebase_functions = ["py.typed"]
 
 [tool.setuptools.dynamic]
-version = {attr = "firebase_functions.__version__"}
+version = { attr = "firebase_functions.__version__" }
 
 [tool.pytest.ini_options]
-pythonpath = [
-  ".", "src/",
-]
+pythonpath = [".", "src/"]
 
 [tool.coverage]
-    [tool.coverage.run]
-    omit = [
-        '__init__.py',
-        'tests/*',
-        '*/tests/*',
-    ]
+[tool.coverage.run]
+omit = ['__init__.py', 'tests/*', '*/tests/*']
 
-    [tool.coverage.report]
-    skip_empty = true
+[tool.coverage.report]
+skip_empty = true
 
 [tool.ruff]
 target-version = "py310"
@@ -86,23 +81,23 @@ indent-width = 4
 
 [tool.ruff.lint]
 select = [
-    "E",      # pycodestyle errors
-    "W",      # pycodestyle warnings
-    "F",      # pyflakes
-    "I",      # isort
-    "UP",     # pyupgrade
-    "B",      # flake8-bugbear
-    "C4",     # flake8-comprehensions
-    "PL",     # pylint
+  "E",  # pycodestyle errors
+  "W",  # pycodestyle warnings
+  "F",  # pyflakes
+  "I",  # isort
+  "UP", # pyupgrade
+  "B",  # flake8-bugbear
+  "C4", # flake8-comprehensions
+  "PL", # pylint
 ]
 ignore = [
-    "PLR0913", # Too many arguments
-    "PLR0912", # Too many branches
-    "PLR0915", # Too many statements
-    "PLR2004", # Magic value used in comparison
-    "PLW0603", # Using the global statement
-    "PLC0415", # Import outside toplevel
-    "E501",    # Line too long (handled by formatter)
+  "PLR0913", # Too many arguments
+  "PLR0912", # Too many branches
+  "PLR0915", # Too many statements
+  "PLR2004", # Magic value used in comparison
+  "PLW0603", # Using the global statement
+  "PLC0415", # Import outside toplevel
+  "E501",    # Line too long (handled by formatter)
 ]
 
 [tool.ruff.format]
@@ -110,3 +105,4 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+


### PR DESCRIPTION
Formatter is causing some churn, but the real diff is:

```toml
[tool.setuptools]
package-dir = { "" = "src" }
[tool.setuptools.packages.find]
where = ["src"]
```

to make sure that we include all subpackages (e.g. `firebase_functions/private` and `firebase_functions/alerts`) in the built package.