### PR TITLE
fix(util): improve the robustness of timestamp conversion function

### DIFF
--- a/src/firebase_functions/private/util.py
+++ b/src/firebase_functions/private/util.py
@@ -409,7 +409,7 @@ def timestamp_conversion(time) -> _dt.datetime:
     """
     # Handle Firebase Timestamp object case
     # Accept dict-like objects, or python objects with 'seconds' and 'nanoseconds' attributes
-    if hasattr(time, 'seconds') and hasattr(time, 'nanoseconds'):
+    if hasattr(time, "seconds") and hasattr(time, "nanoseconds"):
         # Use UTC time
         return _dt.datetime.fromtimestamp(
             time.seconds + time.nanoseconds / 1_000_000_000, tz=_dt.timezone.utc

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -196,6 +196,7 @@ def test_timestamp_conversion_with_object():
     """
     Testing timestamp_conversion works with objects that have seconds and nanoseconds attributes.
     """
+
     class Timestamp:
         def __init__(self, seconds, nanoseconds):
             self.seconds = seconds
@@ -256,6 +257,7 @@ def test_timestamp_conversion_errors():
     """
     Testing timestamp_conversion raises appropriate errors for invalid inputs.
     """
+
     class IncompleteTimestamp:
         def __init__(self, nanoseconds):
             self.nanoseconds = nanoseconds
@@ -274,4 +276,3 @@ def test_timestamp_conversion_errors():
 
     with pytest.raises(ValueError):
         timestamp_conversion(None)
-


### PR DESCRIPTION
Resolves https://github.com/firebase/firebase-functions-python/issues/260

Make timestamp conversion handle string, dict, or object input with "seconds" and "nanoseconds" attributes, improving robustness and adding tests for these cases.