### PR TITLE
feat: merge attemptDeadlineSeconds and timeoutSeconds option for v2 scheduled functions

### DIFF
--- a/src/firebase_functions/options.py
+++ b/src/firebase_functions/options.py
@@ -869,6 +869,7 @@ class ScheduleOptions(RuntimeOptions):
                 schedule=self.schedule,
                 timeZone=time_zone,
                 retryConfig=retry_config,
+                attemptDeadlineSeconds=self.timeout_sec,
             ),
         }
         return _manifest.ManifestEndpoint(**_typing.cast(dict, kwargs_merged))

--- a/src/firebase_functions/private/manifest.py
+++ b/src/firebase_functions/private/manifest.py
@@ -125,6 +125,7 @@ class ScheduleTrigger(_typing.TypedDict):
     schedule: str | _params.Expression[str]
     timeZone: str | _params.Expression[str] | _util.Sentinel | None
     retryConfig: RetryConfigScheduler | None
+    attemptDeadlineSeconds: int | _params.Expression[int] | _util.Sentinel | None
 
 
 class BlockingTriggerOptions(_typing.TypedDict):

--- a/tests/test_scheduler_fn.py
+++ b/tests/test_scheduler_fn.py
@@ -47,6 +47,18 @@ class TestScheduler(unittest.TestCase):
         self.assertEqual(endpoint.scheduleTrigger.get("schedule"), schedule)
         self.assertEqual(endpoint.scheduleTrigger.get("timeZone"), tz)
 
+    def test_on_schedule_with_timeout(self):
+        """
+        Tests that attemptDeadlineSeconds is set to timeoutSeconds.
+        """
+        decorated_func = scheduler_fn.on_schedule(
+            schedule="* * * * *",
+            timeout_sec=120,
+        )(Mock(__name__="example_func"))
+        endpoint = decorated_func.__firebase_endpoint__
+        self.assertEqual(endpoint.timeoutSeconds, 120)
+        self.assertEqual(endpoint.scheduleTrigger.get("attemptDeadlineSeconds"), 120)
+
     def test_on_schedule_call(self):
         """
         Tests to ensure the decorated function is called correctly


### PR DESCRIPTION
We are removing explicit control for users to set `attemptDeadlineSeconds`. This is because we feel that `attemptDeadlineSeconds` and `timeoutSeconds` for the function is deeply coupled - there isn't a valid use case we can think of that requires the two values to be different.

Per Cloud Scheduler docs:


> The deadline for job attempts. If the request handler does not respond by this deadline then the request is cancelled and the attempt is marked as a DEADLINE_EXCEEDED failure. The failed attempt can be viewed in execution logs. Cloud Scheduler will retry the job according to the [RetryConfig](https://docs.cloud.google.com/scheduler/docs/reference/rest/v1beta1/projects.locations.jobs#RetryConfig).
>
> The default and the allowed values depend on the type of target:
>
> For [HTTP targets](https://docs.cloud.google.com/scheduler/docs/reference/rest/v1beta1/projects.locations.jobs#Job.FIELDS.http_target), the default is 3 minutes. The deadline must be in the interval [15 seconds, 30 minutes]. 

Effectively, we believe function timeout ~= attemptDeadline (ideally attemptDeadline should be a second or two greater than function timeout, but we leave that out as edge case for now)