### PR TITLE
add authcontxt params to database_event

### DIFF
--- a/src/firebase_functions/db_fn.py
+++ b/src/firebase_functions/db_fn.py
@@ -74,7 +74,7 @@ class Event(_core.CloudEvent[T]):
     The type of principal that triggered the event.
     """
 
-    auth_id: str
+    auth_id: str | None
     """
     The unique identifier for the principal.
     """
@@ -117,9 +117,6 @@ def _db_endpoint_handler(
         **instance_pattern.extract_matches(event_instance),
     }
 
-    event_auth_type = event_attributes["authtype"]
-    event_auth_id = event_attributes["authid"]
-
     database_event = Event(
         firebase_database_host=event_attributes["firebasedatabasehost"],
         instance=event_instance,
@@ -136,8 +133,8 @@ def _db_endpoint_handler(
         data=database_event_data,
         subject=event_attributes["subject"],
         params=params,
-        auth_type=event_auth_type,
-        auth_id=event_auth_id,
+        auth_type=event_attributes.get("authtype", "unknown"),
+        auth_id=event_attributes.get("authid"),
     )
     _core._with_init(func)(database_event)
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -38,10 +38,18 @@ class TestDb(unittest.TestCase):
                 "ref": "ref",
                 "firebasedatabasehost": "firebasedatabasehost",
                 "location": "location",
+                "authtype": "app_user",
+                "authid": "auth-id",
             },
             data={"delta": "delta"},
         )
 
         decorated_func(event)
+
+        func.assert_called_once()
+        event = func.call_args.args[0]
+        self.assertIsNotNone(event)
+        self.assertEqual(event.auth_type, "app_user")
+        self.assertEqual(event.auth_id, "auth-id")
 
         self.assertEqual(hello, "world")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -53,3 +53,31 @@ class TestDb(unittest.TestCase):
         self.assertEqual(event.auth_id, "auth-id")
 
         self.assertEqual(hello, "world")
+
+    def test_missing_auth_context(self):
+        func = mock.Mock(__name__="example_func_no_auth")
+        decorated_func = db_fn.on_value_created(reference="path")(func)
+
+        event = CloudEvent(
+            attributes={
+                "specversion": "1.0",
+                "id": "id",
+                "source": "source",
+                "subject": "subject",
+                "type": "type",
+                "time": "2024-04-10T12:00:00.000Z",
+                "instance": "instance",
+                "ref": "ref",
+                "firebasedatabasehost": "firebasedatabasehost",
+                "location": "location",
+            },
+            data={"delta": "delta"},
+        )
+
+        decorated_func(event)
+
+        func.assert_called_once()
+        event_arg = func.call_args.args[0]
+        self.assertIsNotNone(event_arg)
+        self.assertEqual(event_arg.auth_type, "unknown")
+        self.assertIsNone(event_arg.auth_id)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -47,10 +47,10 @@ class TestDb(unittest.TestCase):
         decorated_func(event)
 
         func.assert_called_once()
-        event = func.call_args.args[0]
-        self.assertIsNotNone(event)
-        self.assertEqual(event.auth_type, "app_user")
-        self.assertEqual(event.auth_id, "auth-id")
+        event_arg = func.call_args.args[0]
+        self.assertIsNotNone(event_arg)
+        self.assertEqual(event_arg.auth_type, "app_user")
+        self.assertEqual(event_arg.auth_id, "auth-id")
 
         self.assertEqual(hello, "world")
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -38,7 +38,7 @@ class TestDb(unittest.TestCase):
                 "ref": "ref",
                 "firebasedatabasehost": "firebasedatabasehost",
                 "location": "location",
-                "authtype": "app_user",
+                "authtype": "app-user",
                 "authid": "auth-id",
             },
             data={"delta": "delta"},
@@ -49,7 +49,7 @@ class TestDb(unittest.TestCase):
         func.assert_called_once()
         event = func.call_args.args[0]
         self.assertIsNotNone(event)
-        self.assertEqual(event.auth_type, "app_user")
+        self.assertEqual(event.auth_type, "app-user")
         self.assertEqual(event.auth_id, "auth-id")
 
         self.assertEqual(hello, "world")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -38,7 +38,7 @@ class TestDb(unittest.TestCase):
                 "ref": "ref",
                 "firebasedatabasehost": "firebasedatabasehost",
                 "location": "location",
-                "authtype": "app-user",
+                "authtype": "app_user",
                 "authid": "auth-id",
             },
             data={"delta": "delta"},
@@ -49,7 +49,7 @@ class TestDb(unittest.TestCase):
         func.assert_called_once()
         event = func.call_args.args[0]
         self.assertIsNotNone(event)
-        self.assertEqual(event.auth_type, "app-user")
+        self.assertEqual(event.auth_type, "app_user")
         self.assertEqual(event.auth_id, "auth-id")
 
         self.assertEqual(hello, "world")


### PR DESCRIPTION
**Description**
Add authctxt fields so users can access them in their v2 functions.

**Code sample**
```
@db_fn.on_value_written(reference="/messages/{pushId}/original")
def makeuppercase_ifnotadmin(event: db_fn.Event[db_fn.Change]) -> None:
    """Listens for new messages added to /messages/{pushId}/original and
    creates an uppercase version of the message to /messages/{pushId}/uppercase
    """
  
    # Only edit data if it is not from admin
    if event.auth_type == "admin":
        return

    # Only edit data when it is first created.
    if event.data.before is not None:
        return

    # Exit when the data is deleted.
    if event.data.after is None:
        return

    # Grab the value that was written to the Realtime Database.
    original = event.data.after
    if not hasattr(original, "upper"):
        print(f"Not a string: {event.reference}")
        return

    # Use the Admin SDK to set an "uppercase" sibling.
    print(f"Uppercasing {event.params['pushId']}: {original}")
    upper = original.upper()
    parent = db.reference(event.reference).parent
    if parent is None:
        print("Message can't be root node.")
        return
    parent.child("uppercase").set(upper)
```
