### PR TITLE
fix: bug where init isn't called with cors enabled

### DIFF
--- a/src/firebase_functions/https_fn.py
+++ b/src/firebase_functions/https_fn.py
@@ -438,7 +438,7 @@ def on_request(**kwargs) -> _typing.Callable[[_C1], _C1]:
                 return _cross_origin(
                     methods=options.cors.cors_methods,
                     origins=options.cors.cors_origins,
-                )(func)(request)
+                )(_core._with_init(func))(request)
             return _core._with_init(func)(request)
 
         _util.set_func_endpoint_attr(

--- a/src/firebase_functions/https_fn.py
+++ b/src/firebase_functions/https_fn.py
@@ -432,14 +432,19 @@ def on_request(**kwargs) -> _typing.Callable[[_C1], _C1]:
     options = HttpsOptions(**kwargs)
 
     def on_request_inner_decorator(func: _C1):
+        func_with_init = _core._with_init(func)
+
+        if options.cors is not None:
+            wrapped_function = _cross_origin(
+                methods=options.cors.cors_methods,
+                origins=options.cors.cors_origins,
+            )(func_with_init)
+        else:
+            wrapped_function = func_with_init
+
         @_functools.wraps(func)
         def on_request_wrapped(request: Request) -> Response:
-            if options.cors is not None:
-                return _cross_origin(
-                    methods=options.cors.cors_methods,
-                    origins=options.cors.cors_origins,
-                )(_core._with_init(func))(request)
-            return _core._with_init(func)(request)
+            return wrapped_function(request)
 
         _util.set_func_endpoint_attr(
             on_request_wrapped,

--- a/tests/test_https_fn.py
+++ b/tests/test_https_fn.py
@@ -9,6 +9,7 @@ from flask import Flask, Request
 from werkzeug.test import EnvironBuilder
 
 from firebase_functions import core, https_fn
+from firebase_functions.options import CorsOptions
 
 
 class TestHttps(unittest.TestCase):
@@ -37,6 +38,34 @@ class TestHttps(unittest.TestCase):
             ).get_environ()
             request = Request(environ)
             decorated_func = https_fn.on_request()(func)
+
+            decorated_func(request)
+
+        self.assertEqual(hello, "world")
+
+    def test_on_request_calls_init_function_with_cors(self):
+        app = Flask(__name__)
+
+        hello = None
+
+        @core.init
+        def init():
+            nonlocal hello
+            hello = "world"
+
+        func = Mock(__name__="example_func", return_value="OK")
+
+        with app.test_request_context("/"):
+            environ = EnvironBuilder(
+                method="POST",
+                json={
+                    "data": {"test": "value"},
+                },
+            ).get_environ()
+            request = Request(environ)
+            decorated_func = https_fn.on_request(
+                cors=CorsOptions(cors_origins="*", cors_methods="GET")
+            )(func)
 
             decorated_func(request)
 


### PR DESCRIPTION
Fixes #251 

In the code path for when CORs is enabled we simply seem to be missing the `_with_init` wrapper that is present on the path for when CORs is not enabled. It is assumed this is simply a mistake.