### PR TITLE
fix: add tzdata as a required dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,7 @@ dependencies = [
   "pyjwt[crypto]>=2.5.0",
   "google-events==0.5.0",
   "google-cloud-firestore>=2.11.0",
-  "tzdata>=2024.1"
-
+  "tzdata>=2024.1",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
   "pyjwt[crypto]>=2.5.0",
   "google-events==0.5.0",
   "google-cloud-firestore>=2.11.0",
+  "tzdata>=2024.1"
+
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

Fix scheduler test failures in environments that do not have timezone data installed by adding `tzdata` as a required dependency.

## Problem/Root Cause

Issue [#258](https://github.com/firebase/firebase-functions-python/issues/258) reports that `test_on_schedule_call` and `test_on_schedule_decorator` fail with `ZoneInfoNotFoundError` for `America/Los_Angeles` when the runtime environment does not have the `tzdata` package available.

The root cause is that the package relies on timezone data through Python's `zoneinfo` support, but `tzdata` was not listed in the project's required dependencies. That left installs dependent on environment-specific system timezone data being present.

## Solution/Changes

Add `tzdata>=2024.1` to the `[project].dependencies` list in `pyproject.toml` so timezone data is installed as part of the package's normal dependency set.

This removes the environment-specific dependency on preinstalled timezone data and ensures the scheduler code has access to the timezone definitions it needs in environments where system tzdata is missing.

## Testing

- Manually verified that this patch ensures that both tests pass in the following [MRE](https://github.com/invertase/cloud-team-mre/tree/firebase/firebase-functions-python/issue-258/firebase/firebase-functions-python/issue-258).
