### PR TITLE
feat: support logging of exceptions

### DIFF
--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -5,8 +5,8 @@ Logger module for Firebase Functions.
 import enum as _enum
 import json as _json
 import sys as _sys
-import typing as _typing
 import traceback as _traceback
+import typing as _typing
 
 import typing_extensions as _typing_extensions
 
@@ -88,9 +88,7 @@ def _exception_from_args(
     if exception.__traceback__ is not None:
         try:
             details["stack_trace"] = "".join(
-                _traceback.format_exception(
-                    exception.__class__, exception, exception.__traceback__
-                )
+                _traceback.format_exception(exception.__class__, exception, exception.__traceback__)
             )
         except Exception:
             details["stack_trace"] = "".join(_traceback.format_tb(exception.__traceback__))

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -44,6 +44,7 @@ class LogEntry(_typing.TypedDict):
 
     severity: _typing_extensions.Required[LogSeverity]
     message: _typing_extensions.NotRequired[str]
+    stack_trace: _typing_extensions.NotRequired[str]
 
 
 def _entry_from_args(severity: LogSeverity, *args, **kwargs) -> LogEntry:

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -148,9 +148,7 @@ def _coerce_json_safe(obj: _typing.Any):
     if isinstance(obj, str | int | float | bool | type(None)):
         return obj
     if isinstance(obj, dict):
-        return {
-            _coerce_json_safe(key): _coerce_json_safe(value) for key, value in obj.items()
-        }
+        return {_coerce_json_safe(key): _coerce_json_safe(value) for key, value in obj.items()}
     if isinstance(obj, list):
         return [_coerce_json_safe(item) for item in obj]
     if isinstance(obj, tuple):

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -258,7 +258,9 @@ def exception(*args, **kwargs) -> None:
     entry = _entry_from_args(LogSeverity.ERROR, *args, **kwargs)
     exc_type, exc_value, exc_traceback = _sys.exc_info()
     if exc_type is not None and exc_value is not None and exc_traceback is not None:
-        entry["stack_trace"] = "".join(
-            _traceback.format_exception(exc_type, exc_value, exc_traceback)
-        )
+        error = entry.get("error")
+        if not isinstance(error, dict) or "stack_trace" not in error:
+            entry["stack_trace"] = "".join(
+                _traceback.format_exception(exc_type, exc_value, exc_traceback)
+            )
     write(entry)

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -85,7 +85,7 @@ def _exception_from_args(
         "message": _safe_exception_string(exception),
     }
     if exception.args:
-        details["args"] = _remove_circular(exception.args, refs)
+        details["args"] = _json_safe_exception_args(exception.args, refs)
     if exception.__traceback__ is not None:
         try:
             details["stack_trace"] = "".join(
@@ -130,6 +130,30 @@ def _safe_exception_string(exception: BaseException) -> str:
         return str(exception)
     except Exception:
         return exception.__class__.__name__
+
+
+def _json_safe_exception_args(args: tuple[_typing.Any, ...], refs: set[int] | None = None):
+    """
+    Returns exception args in a form that can be encoded as JSON.
+    """
+
+    return _coerce_json_safe(_remove_circular(args, refs))
+
+
+def _coerce_json_safe(obj: _typing.Any):
+    """
+    Converts values that survive circular-reference removal into JSON-safe values.
+    """
+
+    if isinstance(obj, str | int | float | bool | type(None)):
+        return obj
+    if isinstance(obj, dict):
+        return {key: _coerce_json_safe(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_coerce_json_safe(item) for item in obj]
+    if isinstance(obj, tuple):
+        return tuple(_coerce_json_safe(item) for item in obj)
+    return repr(obj)
 
 
 def _remove_circular(obj: _typing.Any, refs: set[int] | None = None):

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -148,12 +148,27 @@ def _coerce_json_safe(obj: _typing.Any):
     if isinstance(obj, str | int | float | bool | type(None)):
         return obj
     if isinstance(obj, dict):
-        return {_coerce_json_safe(key): _coerce_json_safe(value) for key, value in obj.items()}
+        return {
+            _coerce_json_safe_dict_key(key): _coerce_json_safe(value) for key, value in obj.items()
+        }
     if isinstance(obj, list):
         return [_coerce_json_safe(item) for item in obj]
     if isinstance(obj, tuple):
         return tuple(_coerce_json_safe(item) for item in obj)
     return _safe_repr(obj)
+
+
+def _coerce_json_safe_dict_key(obj: _typing.Any):
+    """
+    Converts dictionary keys into values accepted by JSON object encoding.
+    """
+
+    if isinstance(obj, str | int | float | bool | type(None)):
+        return obj
+    coerced = _coerce_json_safe(obj)
+    if isinstance(coerced, str | int | float | bool | type(None)):
+        return coerced
+    return _safe_repr(coerced)
 
 
 def _safe_repr(obj: _typing.Any) -> str:

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -56,69 +56,76 @@ def _entry_from_args(severity: LogSeverity, *args, **kwargs) -> LogEntry:
         [
             value
             if isinstance(value, str)
-            else _json.dumps(_remove_circular(value), ensure_ascii=False)
+            else _json.dumps(_coerce_json_safe(_remove_circular(value)), ensure_ascii=False)
             for value in args
         ]
     )
 
     other: dict[str, _typing.Any] = {
-        key: value if isinstance(value, str) else _remove_circular(value)
+        key: value if isinstance(value, str) else _coerce_json_safe(_remove_circular(value))
         for key, value in kwargs.items()
     }
 
     entry: dict[str, _typing.Any] = {"severity": severity, **other}
     if message:
         entry["message"] = message
+    if severity == LogSeverity.ERROR:
+        stack_trace = _stack_trace_from_args(args, kwargs)
+        if stack_trace is not None:
+            entry["stack_trace"] = stack_trace
 
     return _typing.cast(LogEntry, entry)
 
 
-def _exception_from_args(
-    exception: BaseException, refs: set[int] | None = None
-) -> dict[str, _typing.Any]:
+def _stack_trace_from_exception(exception: BaseException) -> str | None:
     """
-    Creates a JSON-safe representation of an exception.
+    Returns a formatted stack trace for an exception when available.
     """
 
-    details: dict[str, _typing.Any] = {
-        "type": exception.__class__.__name__,
-        "message": _safe_exception_string(exception),
-    }
-    if exception.args:
-        details["args"] = _json_safe_exception_args(exception.args, refs)
     if exception.__traceback__ is not None:
         try:
-            details["stack_trace"] = "".join(
+            return "".join(
                 _traceback.format_exception(exception.__class__, exception, exception.__traceback__)
             )
         except Exception:
-            details["stack_trace"] = "".join(_traceback.format_tb(exception.__traceback__))
-            details["stack_trace"] += f"{exception.__class__.__name__}: {details['message']}\n"
-    return details
+            stack_trace = "".join(_traceback.format_tb(exception.__traceback__))
+            stack_trace += f"{exception.__class__.__name__}: {_safe_exception_string(exception)}\n"
+            return stack_trace
+    return None
 
 
-def _exception_type_from_args(
-    exception_type: type[BaseException],
-) -> dict[str, _typing.Any]:
+def _stack_trace_from_exception_type(exception_type: type[BaseException]) -> str | None:
     """
-    Creates a JSON-safe representation of an exception class.
-
-    If the class matches the active exception from `sys.exc_info()`, include
-    the current exception message and stack trace as well.
+    Returns the active stack trace when the given type matches the current exception.
     """
 
-    details: dict[str, _typing.Any] = {
-        "type": exception_type.__name__,
-        "message": exception_type.__name__,
-    }
     exc_type, exc_value, exc_traceback = _sys.exc_info()
     if exc_type is exception_type and exc_value is not None:
-        details["message"] = _safe_exception_string(exc_value)
         if exc_traceback is not None:
-            details["stack_trace"] = "".join(
-                _traceback.format_exception(exc_type, exc_value, exc_traceback)
-            )
-    return details
+            return "".join(_traceback.format_exception(exc_type, exc_value, exc_traceback))
+    return None
+
+
+def _stack_trace_from_args(args: tuple[_typing.Any, ...], kwargs: dict[str, _typing.Any]) -> str | None:
+    """
+    Returns the first available stack trace from logger arguments or active exception state.
+    """
+
+    for value in (*args, *kwargs.values()):
+        if isinstance(value, BaseException):
+            stack_trace = _stack_trace_from_exception(value)
+            if stack_trace is not None:
+                return stack_trace
+        elif isinstance(value, type) and issubclass(value, BaseException):
+            stack_trace = _stack_trace_from_exception_type(value)
+            if stack_trace is not None:
+                return stack_trace
+
+    exc_type, exc_value, exc_traceback = _sys.exc_info()
+    if exc_type is not None and exc_value is not None and exc_traceback is not None:
+        return "".join(_traceback.format_exception(exc_type, exc_value, exc_traceback))
+
+    return None
 
 
 def _safe_exception_string(exception: BaseException) -> str:
@@ -130,14 +137,6 @@ def _safe_exception_string(exception: BaseException) -> str:
         return str(exception)
     except Exception:
         return exception.__class__.__name__
-
-
-def _json_safe_exception_args(args: tuple[_typing.Any, ...], refs: set[int] | None = None):
-    """
-    Returns exception args in a form that can be encoded as JSON.
-    """
-
-    return _coerce_json_safe(_remove_circular(args, refs))
 
 
 def _coerce_json_safe(obj: _typing.Any):
@@ -200,11 +199,7 @@ def _remove_circular(obj: _typing.Any, refs: set[int] | None = None):
 
     # Recursively process the object based on its type
     result: _typing.Any
-    if isinstance(obj, BaseException):
-        result = _exception_from_args(obj, refs)
-    elif isinstance(obj, type) and issubclass(obj, BaseException):
-        result = _exception_type_from_args(obj)
-    elif isinstance(obj, dict):
+    if isinstance(obj, dict):
         result = {key: _remove_circular(value, refs) for key, value in obj.items()}
     elif isinstance(obj, list):
         result = [_remove_circular(item, refs) for item in obj]
@@ -264,19 +259,3 @@ def error(*args, **kwargs) -> None:
     Logs an error message.
     """
     write(_entry_from_args(LogSeverity.ERROR, *args, **kwargs))
-
-
-def exception(*args, **kwargs) -> None:
-    """
-    Logs an error message and includes the active stack trace.
-    """
-    raw_error = kwargs.get("error")
-    entry = _entry_from_args(LogSeverity.ERROR, *args, **kwargs)
-    exc_type, exc_value, exc_traceback = _sys.exc_info()
-    if exc_type is not None and exc_value is not None and exc_traceback is not None:
-        uses_active_error_traceback = raw_error is exc_value or raw_error is exc_type
-        if not uses_active_error_traceback:
-            entry["stack_trace"] = "".join(
-                _traceback.format_exception(exc_type, exc_value, exc_traceback)
-            )
-    write(entry)

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -6,6 +6,7 @@ import enum as _enum
 import json as _json
 import sys as _sys
 import typing as _typing
+import traceback as _traceback
 
 import typing_extensions as _typing_extensions
 
@@ -71,6 +72,43 @@ def _entry_from_args(severity: LogSeverity, *args, **kwargs) -> LogEntry:
     return _typing.cast(LogEntry, entry)
 
 
+def _exception_from_args(
+    exception: BaseException, refs: set[_typing.Any] | None = None
+) -> dict[str, _typing.Any]:
+    """
+    Creates a JSON-safe representation of an exception.
+    """
+
+    details: dict[str, _typing.Any] = {
+        "type": exception.__class__.__name__,
+        "message": _safe_exception_string(exception),
+    }
+    if exception.args:
+        details["args"] = _remove_circular(exception.args, refs)
+    if exception.__traceback__ is not None:
+        try:
+            details["stack_trace"] = "".join(
+                _traceback.format_exception(
+                    exception.__class__, exception, exception.__traceback__
+                )
+            )
+        except Exception:
+            details["stack_trace"] = "".join(_traceback.format_tb(exception.__traceback__))
+            details["stack_trace"] += f"{exception.__class__.__name__}: {details['message']}\n"
+    return details
+
+
+def _safe_exception_string(exception: BaseException) -> str:
+    """
+    Returns a string representation of an exception without propagating repr/str errors.
+    """
+
+    try:
+        return str(exception)
+    except Exception:
+        return exception.__class__.__name__
+
+
 def _remove_circular(obj: _typing.Any, refs: set[_typing.Any] | None = None):
     """
     Removes circular references from the given object and replaces them with "[CIRCULAR]".
@@ -89,7 +127,9 @@ def _remove_circular(obj: _typing.Any, refs: set[_typing.Any] | None = None):
 
     # Recursively process the object based on its type
     result: _typing.Any
-    if isinstance(obj, dict):
+    if isinstance(obj, BaseException):
+        result = _exception_from_args(obj, refs)
+    elif isinstance(obj, dict):
         result = {key: _remove_circular(value, refs) for key, value in obj.items()}
     elif isinstance(obj, list):
         result = [_remove_circular(item, refs) for item in obj]
@@ -149,3 +189,16 @@ def error(*args, **kwargs) -> None:
     Logs an error message.
     """
     write(_entry_from_args(LogSeverity.ERROR, *args, **kwargs))
+
+
+def exception(*args, **kwargs) -> None:
+    """
+    Logs an error message and includes the active stack trace.
+    """
+    entry = _entry_from_args(LogSeverity.ERROR, *args, **kwargs)
+    exc_type, exc_value, exc_traceback = _sys.exc_info()
+    if exc_type is not None and exc_value is not None and exc_traceback is not None:
+        entry["stack_trace"] = "".join(
+            _traceback.format_exception(exc_type, exc_value, exc_traceback)
+        )
+    write(entry)

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -106,7 +106,9 @@ def _stack_trace_from_exception_type(exception_type: type[BaseException]) -> str
     return None
 
 
-def _stack_trace_from_args(args: tuple[_typing.Any, ...], kwargs: dict[str, _typing.Any]) -> str | None:
+def _stack_trace_from_args(
+    args: tuple[_typing.Any, ...], kwargs: dict[str, _typing.Any]
+) -> str | None:
     """
     Returns the first available stack trace from logger arguments or active exception state.
     """

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -74,7 +74,7 @@ def _entry_from_args(severity: LogSeverity, *args, **kwargs) -> LogEntry:
 
 
 def _exception_from_args(
-    exception: BaseException, refs: set[_typing.Any] | None = None
+    exception: BaseException, refs: set[int] | None = None
 ) -> dict[str, _typing.Any]:
     """
     Creates a JSON-safe representation of an exception.
@@ -108,7 +108,7 @@ def _safe_exception_string(exception: BaseException) -> str:
         return exception.__class__.__name__
 
 
-def _remove_circular(obj: _typing.Any, refs: set[_typing.Any] | None = None):
+def _remove_circular(obj: _typing.Any, refs: set[int] | None = None):
     """
     Removes circular references from the given object and replaces them with "[CIRCULAR]".
     """

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -97,6 +97,30 @@ def _exception_from_args(
     return details
 
 
+def _exception_type_from_args(
+    exception_type: type[BaseException],
+) -> dict[str, _typing.Any]:
+    """
+    Creates a JSON-safe representation of an exception class.
+
+    If the class matches the active exception from `sys.exc_info()`, include
+    the current exception message and stack trace as well.
+    """
+
+    details: dict[str, _typing.Any] = {
+        "type": exception_type.__name__,
+        "message": exception_type.__name__,
+    }
+    exc_type, exc_value, exc_traceback = _sys.exc_info()
+    if exc_type is exception_type and exc_value is not None:
+        details["message"] = _safe_exception_string(exc_value)
+        if exc_traceback is not None:
+            details["stack_trace"] = "".join(
+                _traceback.format_exception(exc_type, exc_value, exc_traceback)
+            )
+    return details
+
+
 def _safe_exception_string(exception: BaseException) -> str:
     """
     Returns a string representation of an exception without propagating repr/str errors.
@@ -128,6 +152,8 @@ def _remove_circular(obj: _typing.Any, refs: set[int] | None = None):
     result: _typing.Any
     if isinstance(obj, BaseException):
         result = _exception_from_args(obj, refs)
+    elif isinstance(obj, type) and issubclass(obj, BaseException):
+        result = _exception_type_from_args(obj)
     elif isinstance(obj, dict):
         result = {key: _remove_circular(value, refs) for key, value in obj.items()}
     elif isinstance(obj, list):

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -270,11 +270,12 @@ def exception(*args, **kwargs) -> None:
     """
     Logs an error message and includes the active stack trace.
     """
+    raw_error = kwargs.get("error")
     entry = _entry_from_args(LogSeverity.ERROR, *args, **kwargs)
     exc_type, exc_value, exc_traceback = _sys.exc_info()
     if exc_type is not None and exc_value is not None and exc_traceback is not None:
-        error = entry.get("error")
-        if not isinstance(error, dict) or "stack_trace" not in error:
+        uses_active_error_traceback = raw_error is exc_value or raw_error is exc_type
+        if not uses_active_error_traceback:
             entry["stack_trace"] = "".join(
                 _traceback.format_exception(exc_type, exc_value, exc_traceback)
             )

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -148,12 +148,25 @@ def _coerce_json_safe(obj: _typing.Any):
     if isinstance(obj, str | int | float | bool | type(None)):
         return obj
     if isinstance(obj, dict):
-        return {key: _coerce_json_safe(value) for key, value in obj.items()}
+        return {
+            _coerce_json_safe(key): _coerce_json_safe(value) for key, value in obj.items()
+        }
     if isinstance(obj, list):
         return [_coerce_json_safe(item) for item in obj]
     if isinstance(obj, tuple):
         return tuple(_coerce_json_safe(item) for item in obj)
-    return repr(obj)
+    return _safe_repr(obj)
+
+
+def _safe_repr(obj: _typing.Any) -> str:
+    """
+    Returns a repr without propagating repr errors.
+    """
+
+    try:
+        return repr(obj)
+    except Exception:
+        return obj.__class__.__name__
 
 
 def _remove_circular(obj: _typing.Any, refs: set[int] | None = None):

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -88,7 +88,6 @@ def _stack_trace_from_exception(exception: BaseException) -> str | None:
                 _traceback.format_exception(exception.__class__, exception, exception.__traceback__)
             )
         except Exception:
-
             # We intentionally divergence from the JS SDK here:
             # JS stores error traces in `message`, but Python emits a top-level `stack_trace`
             # because Google Cloud Error Reporting only inspects top-level error fields
@@ -111,7 +110,6 @@ def _stack_trace_from_exception_type(exception_type: type[BaseException]) -> str
         if exc_traceback is not None:
             return "".join(_traceback.format_exception(exc_type, exc_value, exc_traceback))
     return None
-
 
 
 def _stack_trace_from_args(

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -229,7 +229,9 @@ def _get_write_file(severity: LogSeverity) -> _typing.TextIO:
 
 def write(entry: LogEntry) -> None:
     write_file = _get_write_file(entry["severity"])
-    print(_json.dumps(_coerce_json_safe(_remove_circular(entry)), ensure_ascii=False), file=write_file)
+    print(
+        _json.dumps(_coerce_json_safe(_remove_circular(entry)), ensure_ascii=False), file=write_file
+    )
 
 
 def debug(*args, **kwargs) -> None:

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -72,8 +72,12 @@ def _entry_from_args(severity: LogSeverity, *args, **kwargs) -> LogEntry:
     if severity == LogSeverity.ERROR:
         stack_trace = _stack_trace_from_args(args, kwargs)
         if stack_trace is not None:
+            # We intentionally diverge from the JS SDK here:
+            # JS stores error traces in `message`, but Python emits a top-level `stack_trace`
+            # because Google Cloud Error Reporting only inspects top-level error fields
+            # (`stack_trace`, `exception`, `message`). Do not move this trace under `error`
+            # or fold it back into nested payloads, or Error Reporting may stop detecting it.
             entry["stack_trace"] = stack_trace
-
     return _typing.cast(LogEntry, entry)
 
 
@@ -88,12 +92,6 @@ def _stack_trace_from_exception(exception: BaseException) -> str | None:
                 _traceback.format_exception(exception.__class__, exception, exception.__traceback__)
             )
         except Exception:
-            # We intentionally divergence from the JS SDK here:
-            # JS stores error traces in `message`, but Python emits a top-level `stack_trace`
-            # because Google Cloud Error Reporting only inspects top-level error fields
-            # (`stack_trace`, `exception`, `message`). Do not move this trace under `error`
-            # or fold it back into nested payloads, or Error Reporting may stop detecting it.
-
             stack_trace = "".join(_traceback.format_tb(exception.__traceback__))
             stack_trace += f"{exception.__class__.__name__}: {_safe_exception_string(exception)}\n"
             return stack_trace

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -88,6 +88,13 @@ def _stack_trace_from_exception(exception: BaseException) -> str | None:
                 _traceback.format_exception(exception.__class__, exception, exception.__traceback__)
             )
         except Exception:
+
+            # We intentionally divergence from the JS SDK here:
+            # JS stores error traces in `message`, but Python emits a top-level `stack_trace`
+            # because Google Cloud Error Reporting only inspects top-level error fields
+            # (`stack_trace`, `exception`, `message`). Do not move this trace under `error`
+            # or fold it back into nested payloads, or Error Reporting may stop detecting it.
+
             stack_trace = "".join(_traceback.format_tb(exception.__traceback__))
             stack_trace += f"{exception.__class__.__name__}: {_safe_exception_string(exception)}\n"
             return stack_trace
@@ -104,6 +111,7 @@ def _stack_trace_from_exception_type(exception_type: type[BaseException]) -> str
         if exc_traceback is not None:
             return "".join(_traceback.format_exception(exc_type, exc_value, exc_traceback))
     return None
+
 
 
 def _stack_trace_from_args(

--- a/src/firebase_functions/logger.py
+++ b/src/firebase_functions/logger.py
@@ -145,7 +145,7 @@ def _safe_exception_string(exception: BaseException) -> str:
         return exception.__class__.__name__
 
 
-def _coerce_json_safe(obj: _typing.Any):
+def _coerce_json_safe(obj: _typing.Any) -> _typing.Any:
     """
     Converts values that survive circular-reference removal into JSON-safe values.
     """
@@ -163,7 +163,7 @@ def _coerce_json_safe(obj: _typing.Any):
     return _safe_repr(obj)
 
 
-def _coerce_json_safe_dict_key(obj: _typing.Any):
+def _coerce_json_safe_dict_key(obj: _typing.Any) -> _typing.Any:
     """
     Converts dictionary keys into values accepted by JSON object encoding.
     """
@@ -229,7 +229,7 @@ def _get_write_file(severity: LogSeverity) -> _typing.TextIO:
 
 def write(entry: LogEntry) -> None:
     write_file = _get_write_file(entry["severity"])
-    print(_json.dumps(_remove_circular(entry), ensure_ascii=False), file=write_file)
+    print(_json.dumps(_coerce_json_safe(_remove_circular(entry)), ensure_ascii=False), file=write_file)
 
 
 def debug(*args, **kwargs) -> None:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -75,7 +75,9 @@ class TestLogger:
         assert "stack_trace" in log_output["error"]
         assert "ValueError: boom" in log_output["error"]["stack_trace"]
 
-    def test_error_should_accept_self_referential_exception(self, capsys: pytest.CaptureFixture[str]):
+    def test_error_should_accept_self_referential_exception(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
         class SelfArgError(Exception):
             pass
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -59,6 +59,56 @@ class TestLogger:
         log_output = json.loads(raw_log_output)
         assert log_output["severity"] == "ERROR"
 
+    def test_error_should_accept_exception(self, capsys: pytest.CaptureFixture[str]):
+        try:
+            raise ValueError("boom")
+        except ValueError as exception:
+            logger.error("failed", error=exception)
+
+        raw_log_output = capsys.readouterr().err
+        log_output = json.loads(raw_log_output)
+
+        assert log_output["severity"] == "ERROR"
+        assert log_output["message"] == "failed"
+        assert log_output["error"]["type"] == "ValueError"
+        assert log_output["error"]["message"] == "boom"
+        assert "stack_trace" in log_output["error"]
+        assert "ValueError: boom" in log_output["error"]["stack_trace"]
+
+    def test_error_should_accept_self_referential_exception(self, capsys: pytest.CaptureFixture[str]):
+        class SelfArgError(Exception):
+            pass
+
+        exception = SelfArgError("boom")
+        exception.args = (exception,)
+
+        logger.error("failed", error=exception)
+
+        raw_log_output = capsys.readouterr().err
+        log_output = json.loads(raw_log_output)
+
+        assert log_output["severity"] == "ERROR"
+        assert log_output["message"] == "failed"
+        assert log_output["error"]["type"] == "SelfArgError"
+        assert log_output["error"]["args"] == ["[CIRCULAR]"]
+
+    def test_error_should_accept_exception_with_cyclic_payload(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
+        payload = {}
+        payload["self"] = payload
+        exception = ValueError(payload)
+
+        logger.error("failed", error=exception)
+
+        raw_log_output = capsys.readouterr().err
+        log_output = json.loads(raw_log_output)
+
+        assert log_output["severity"] == "ERROR"
+        assert log_output["message"] == "failed"
+        assert log_output["error"]["type"] == "ValueError"
+        assert log_output["error"]["args"] == [{"self": "[CIRCULAR]"}]
+
     def test_log_should_have_message(self, capsys: pytest.CaptureFixture[str]):
         logger.log("bar")
         raw_log_output = capsys.readouterr().out
@@ -77,6 +127,20 @@ class TestLogger:
         raw_log_output = capsys.readouterr().out
         log_output = json.loads(raw_log_output)
         assert log_output["message"] == expected_message
+
+    def test_exception_should_include_stack_trace(self, capsys: pytest.CaptureFixture[str]):
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            logger.exception("failed")
+
+        raw_log_output = capsys.readouterr().err
+        log_output = json.loads(raw_log_output)
+
+        assert log_output["severity"] == "ERROR"
+        assert log_output["message"] == "failed"
+        assert "stack_trace" in log_output
+        assert "ValueError: boom" in log_output["stack_trace"]
 
     def test_remove_circular_references(self, capsys: pytest.CaptureFixture[str]):
         # Create an object with a circular reference.

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -179,6 +179,22 @@ class TestLogger:
         assert log_output["error"]["type"] == "ValueError"
         assert log_output["error"]["args"] == [{repr(next(iter(payload.keys()))): "value"}]
 
+    def test_error_should_accept_exception_with_tuple_dict_key(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
+        payload = {(1, "two"): "value"}
+        exception = ValueError(payload)
+
+        logger.error("failed", error=exception)
+
+        raw_log_output = capsys.readouterr().err
+        log_output = json.loads(raw_log_output)
+
+        assert log_output["severity"] == "ERROR"
+        assert log_output["message"] == "failed"
+        assert log_output["error"]["type"] == "ValueError"
+        assert log_output["error"]["args"] == [{"(1, 'two')": "value"}]
+
     def test_log_should_have_message(self, capsys: pytest.CaptureFixture[str]):
         logger.log("bar")
         raw_log_output = capsys.readouterr().out

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -71,10 +71,11 @@ class TestLogger:
 
         assert log_output["severity"] == "ERROR"
         assert log_output["message"] == "failed"
-        assert log_output["error"]["type"] == "ValueError"
-        assert log_output["error"]["message"] == "boom"
-        assert "stack_trace" in log_output["error"]
-        assert "ValueError: boom" in log_output["error"]["stack_trace"]
+        assert isinstance(log_output["error"], str)
+        assert "ValueError" in log_output["error"]
+        assert "boom" in log_output["error"]
+        assert "stack_trace" in log_output
+        assert "ValueError: boom" in log_output["stack_trace"]
 
     def test_error_should_accept_exception_type(self, capsys: pytest.CaptureFixture[str]):
         try:
@@ -87,10 +88,10 @@ class TestLogger:
 
         assert log_output["severity"] == "ERROR"
         assert log_output["message"] == "failed"
-        assert log_output["error"]["type"] == "TypeError"
-        assert log_output["error"]["message"] == "boom"
-        assert "stack_trace" in log_output["error"]
-        assert "TypeError: boom" in log_output["error"]["stack_trace"]
+        assert isinstance(log_output["error"], str)
+        assert "TypeError" in log_output["error"]
+        assert "stack_trace" in log_output
+        assert "TypeError: boom" in log_output["stack_trace"]
 
     def test_error_should_accept_self_referential_exception(
         self, capsys: pytest.CaptureFixture[str]
@@ -108,8 +109,8 @@ class TestLogger:
 
         assert log_output["severity"] == "ERROR"
         assert log_output["message"] == "failed"
-        assert log_output["error"]["type"] == "SelfArgError"
-        assert log_output["error"]["args"] == ["[CIRCULAR]"]
+        assert isinstance(log_output["error"], str)
+        assert "SelfArgError" in log_output["error"]
 
     def test_error_should_accept_exception_with_cyclic_payload(
         self, capsys: pytest.CaptureFixture[str]
@@ -125,8 +126,9 @@ class TestLogger:
 
         assert log_output["severity"] == "ERROR"
         assert log_output["message"] == "failed"
-        assert log_output["error"]["type"] == "ValueError"
-        assert log_output["error"]["args"] == [{"self": "[CIRCULAR]"}]
+        assert isinstance(log_output["error"], str)
+        assert "ValueError" in log_output["error"]
+        assert "stack_trace" not in log_output
 
     def test_error_should_accept_exception_with_non_json_serializable_args(
         self, capsys: pytest.CaptureFixture[str]
@@ -141,8 +143,8 @@ class TestLogger:
 
         assert log_output["severity"] == "ERROR"
         assert log_output["message"] == "failed"
-        assert log_output["error"]["type"] == "ValueError"
-        assert log_output["error"]["args"] == [repr(payload)]
+        assert isinstance(log_output["error"], str)
+        assert "ValueError" in log_output["error"]
 
     def test_error_should_accept_exception_with_repr_raising_arg(
         self, capsys: pytest.CaptureFixture[str]
@@ -160,8 +162,8 @@ class TestLogger:
 
         assert log_output["severity"] == "ERROR"
         assert log_output["message"] == "failed"
-        assert log_output["error"]["type"] == "ValueError"
-        assert log_output["error"]["args"] == ["BadRepr"]
+        assert isinstance(log_output["error"], str)
+        assert "ValueError" in log_output["error"]
 
     def test_error_should_accept_exception_with_non_json_serializable_dict_key(
         self, capsys: pytest.CaptureFixture[str]
@@ -176,8 +178,8 @@ class TestLogger:
 
         assert log_output["severity"] == "ERROR"
         assert log_output["message"] == "failed"
-        assert log_output["error"]["type"] == "ValueError"
-        assert log_output["error"]["args"] == [{repr(next(iter(payload.keys()))): "value"}]
+        assert isinstance(log_output["error"], str)
+        assert "ValueError" in log_output["error"]
 
     def test_error_should_accept_exception_with_tuple_dict_key(
         self, capsys: pytest.CaptureFixture[str]
@@ -192,8 +194,8 @@ class TestLogger:
 
         assert log_output["severity"] == "ERROR"
         assert log_output["message"] == "failed"
-        assert log_output["error"]["type"] == "ValueError"
-        assert log_output["error"]["args"] == [{"(1, 'two')": "value"}]
+        assert isinstance(log_output["error"], str)
+        assert "ValueError" in log_output["error"]
 
     def test_log_should_have_message(self, capsys: pytest.CaptureFixture[str]):
         logger.log("bar")
@@ -214,11 +216,11 @@ class TestLogger:
         log_output = json.loads(raw_log_output)
         assert log_output["message"] == expected_message
 
-    def test_exception_should_include_stack_trace(self, capsys: pytest.CaptureFixture[str]):
+    def test_error_should_include_active_stack_trace(self, capsys: pytest.CaptureFixture[str]):
         try:
             raise ValueError("boom")
         except ValueError:
-            logger.exception("failed")
+            logger.error("failed")
 
         raw_log_output = capsys.readouterr().err
         log_output = json.loads(raw_log_output)
@@ -228,51 +230,49 @@ class TestLogger:
         assert "stack_trace" in log_output
         assert "ValueError: boom" in log_output["stack_trace"]
 
-    def test_exception_should_not_duplicate_stack_trace_for_exception_error(
+    def test_error_should_surface_top_level_stack_trace_for_exception_error(
         self, capsys: pytest.CaptureFixture[str]
     ):
         try:
             raise ValueError("boom")
         except ValueError as exception:
-            logger.exception("failed", error=exception)
+            logger.error("failed", error=exception)
 
         raw_log_output = capsys.readouterr().err
         log_output = json.loads(raw_log_output)
 
         assert log_output["severity"] == "ERROR"
         assert log_output["message"] == "failed"
-        assert "stack_trace" not in log_output
-        assert log_output["error"]["type"] == "ValueError"
-        assert log_output["error"]["message"] == "boom"
-        assert "stack_trace" in log_output["error"]
-        assert "ValueError: boom" in log_output["error"]["stack_trace"]
+        assert "stack_trace" in log_output
+        assert "ValueError: boom" in log_output["stack_trace"]
+        assert isinstance(log_output["error"], str)
+        assert "ValueError" in log_output["error"]
 
-    def test_exception_should_not_duplicate_stack_trace_for_exception_type_error(
+    def test_error_should_surface_top_level_stack_trace_for_exception_type_error(
         self, capsys: pytest.CaptureFixture[str]
     ):
         try:
             raise TypeError("boom")
         except TypeError:
-            logger.exception("failed", error=sys.exc_info()[0])
+            logger.error("failed", error=sys.exc_info()[0])
 
         raw_log_output = capsys.readouterr().err
         log_output = json.loads(raw_log_output)
 
         assert log_output["severity"] == "ERROR"
         assert log_output["message"] == "failed"
-        assert "stack_trace" not in log_output
-        assert log_output["error"]["type"] == "TypeError"
-        assert log_output["error"]["message"] == "boom"
-        assert "stack_trace" in log_output["error"]
-        assert "TypeError: boom" in log_output["error"]["stack_trace"]
+        assert "stack_trace" in log_output
+        assert "TypeError: boom" in log_output["stack_trace"]
+        assert isinstance(log_output["error"], str)
+        assert "TypeError" in log_output["error"]
 
-    def test_exception_should_include_active_stack_trace_for_error_dict(
+    def test_error_should_not_add_nested_trace_to_error_dict(
         self, capsys: pytest.CaptureFixture[str]
     ):
         try:
             raise ValueError("boom")
         except ValueError:
-            logger.exception("failed", error={"stack_trace": "custom traceback"})
+            logger.error("failed", error={"stack_trace": "custom traceback"})
 
         raw_log_output = capsys.readouterr().err
         log_output = json.loads(raw_log_output)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -212,6 +212,44 @@ class TestLogger:
         assert "stack_trace" in log_output
         assert "ValueError: boom" in log_output["stack_trace"]
 
+    def test_exception_should_not_duplicate_stack_trace_for_exception_error(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
+        try:
+            raise ValueError("boom")
+        except ValueError as exception:
+            logger.exception("failed", error=exception)
+
+        raw_log_output = capsys.readouterr().err
+        log_output = json.loads(raw_log_output)
+
+        assert log_output["severity"] == "ERROR"
+        assert log_output["message"] == "failed"
+        assert "stack_trace" not in log_output
+        assert log_output["error"]["type"] == "ValueError"
+        assert log_output["error"]["message"] == "boom"
+        assert "stack_trace" in log_output["error"]
+        assert "ValueError: boom" in log_output["error"]["stack_trace"]
+
+    def test_exception_should_not_duplicate_stack_trace_for_exception_type_error(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
+        try:
+            raise TypeError("boom")
+        except TypeError:
+            logger.exception("failed", error=sys.exc_info()[0])
+
+        raw_log_output = capsys.readouterr().err
+        log_output = json.loads(raw_log_output)
+
+        assert log_output["severity"] == "ERROR"
+        assert log_output["message"] == "failed"
+        assert "stack_trace" not in log_output
+        assert log_output["error"]["type"] == "TypeError"
+        assert log_output["error"]["message"] == "boom"
+        assert "stack_trace" in log_output["error"]
+        assert "TypeError: boom" in log_output["error"]["stack_trace"]
+
     def test_remove_circular_references(self, capsys: pytest.CaptureFixture[str]):
         # Create an object with a circular reference.
         circ = {"b": "foo"}

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -4,6 +4,7 @@ Logger module tests.
 """
 
 import json
+import sys
 
 import pytest
 
@@ -74,6 +75,22 @@ class TestLogger:
         assert log_output["error"]["message"] == "boom"
         assert "stack_trace" in log_output["error"]
         assert "ValueError: boom" in log_output["error"]["stack_trace"]
+
+    def test_error_should_accept_exception_type(self, capsys: pytest.CaptureFixture[str]):
+        try:
+            raise TypeError("boom")
+        except TypeError:
+            logger.error("failed", error=sys.exc_info()[0])
+
+        raw_log_output = capsys.readouterr().err
+        log_output = json.loads(raw_log_output)
+
+        assert log_output["severity"] == "ERROR"
+        assert log_output["message"] == "failed"
+        assert log_output["error"]["type"] == "TypeError"
+        assert log_output["error"]["message"] == "boom"
+        assert "stack_trace" in log_output["error"]
+        assert "TypeError: boom" in log_output["error"]["stack_trace"]
 
     def test_error_should_accept_self_referential_exception(
         self, capsys: pytest.CaptureFixture[str]

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -144,6 +144,41 @@ class TestLogger:
         assert log_output["error"]["type"] == "ValueError"
         assert log_output["error"]["args"] == [repr(payload)]
 
+    def test_error_should_accept_exception_with_repr_raising_arg(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
+        class BadRepr:
+            def __repr__(self):
+                raise RuntimeError("boom")
+
+        exception = ValueError(BadRepr())
+
+        logger.error("failed", error=exception)
+
+        raw_log_output = capsys.readouterr().err
+        log_output = json.loads(raw_log_output)
+
+        assert log_output["severity"] == "ERROR"
+        assert log_output["message"] == "failed"
+        assert log_output["error"]["type"] == "ValueError"
+        assert log_output["error"]["args"] == ["BadRepr"]
+
+    def test_error_should_accept_exception_with_non_json_serializable_dict_key(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
+        payload = {object(): "value"}
+        exception = ValueError(payload)
+
+        logger.error("failed", error=exception)
+
+        raw_log_output = capsys.readouterr().err
+        log_output = json.loads(raw_log_output)
+
+        assert log_output["severity"] == "ERROR"
+        assert log_output["message"] == "failed"
+        assert log_output["error"]["type"] == "ValueError"
+        assert log_output["error"]["args"] == [{repr(next(iter(payload.keys()))): "value"}]
+
     def test_log_should_have_message(self, capsys: pytest.CaptureFixture[str]):
         logger.log("bar")
         raw_log_output = capsys.readouterr().out

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -266,6 +266,23 @@ class TestLogger:
         assert "stack_trace" in log_output["error"]
         assert "TypeError: boom" in log_output["error"]["stack_trace"]
 
+    def test_exception_should_include_active_stack_trace_for_error_dict(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            logger.exception("failed", error={"stack_trace": "custom traceback"})
+
+        raw_log_output = capsys.readouterr().err
+        log_output = json.loads(raw_log_output)
+
+        assert log_output["severity"] == "ERROR"
+        assert log_output["message"] == "failed"
+        assert log_output["error"] == {"stack_trace": "custom traceback"}
+        assert "stack_trace" in log_output
+        assert "ValueError: boom" in log_output["stack_trace"]
+
     def test_remove_circular_references(self, capsys: pytest.CaptureFixture[str]):
         # Create an object with a circular reference.
         circ = {"b": "foo"}

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -128,6 +128,22 @@ class TestLogger:
         assert log_output["error"]["type"] == "ValueError"
         assert log_output["error"]["args"] == [{"self": "[CIRCULAR]"}]
 
+    def test_error_should_accept_exception_with_non_json_serializable_args(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
+        payload = object()
+        exception = ValueError(payload)
+
+        logger.error("failed", error=exception)
+
+        raw_log_output = capsys.readouterr().err
+        log_output = json.loads(raw_log_output)
+
+        assert log_output["severity"] == "ERROR"
+        assert log_output["message"] == "failed"
+        assert log_output["error"]["type"] == "ValueError"
+        assert log_output["error"]["args"] == [repr(payload)]
+
     def test_log_should_have_message(self, capsys: pytest.CaptureFixture[str]):
         logger.log("bar")
         raw_log_output = capsys.readouterr().out

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -346,6 +346,35 @@ class TestLogger:
         }
         assert log_output == expected
 
+    def test_stack_trace_fallback_when_format_exception_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        def bad_format_exception(*args, **kwargs):
+            raise RuntimeError("format_exception exploded")
+
+        monkeypatch.setattr(logger._traceback, "format_exception", bad_format_exception)
+
+        try:
+            raise ValueError("boom")
+        except ValueError as exception:
+            result = logger._stack_trace_from_exception(exception)
+
+        assert result is not None
+        assert "ValueError" in result
+
+    def test_write_should_coerce_non_json_safe_values(self, capsys: pytest.CaptureFixture[str]):
+        entry = {
+            "severity": logger.LogSeverity.ERROR,
+            "message": "test",
+            "custom": object(),
+        }
+        logger.write(entry)
+        raw_log_output = capsys.readouterr().err
+        log_output = json.loads(raw_log_output)
+        assert log_output["severity"] == "ERROR"
+        assert log_output["message"] == "test"
+        assert isinstance(log_output["custom"], str)
+
     def test_no_false_circular_in_array_duplicates(self, capsys: pytest.CaptureFixture[str]):
         # Ensure that duplicate objects in arrays are not falsely detected as circular.
         obj = {"a": "foo"}


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-functions-python/issues/172

## Summary

This updates `firebase_functions.logger` so `ERROR` logs can safely include exception values and other non-JSON-safe payloads without failing serialization, while aligning the emitted traceback shape with the JS SDK. Stack traces now surface at top-level `stack_trace`, and the Python-only structured exception surface introduced earlier in the PR is removed.

## Problem/Root Cause

The original logger could fail when error metadata included exception-related values that were not directly JSON serializable, including the documented `sys.exc_info()[0]` pattern and exception arguments containing opaque objects, bad `repr()` implementations, or cyclic data.

The initial fix in this PR added a Python-specific structured exception payload under `error` and a new `logger.exception(...)` helper. Reviewer feedback called out that this diverged from the JS SDK's logging shape, especially around traceback placement and the public API surface.

## Solution/Changes

The logger now applies the defensive serialization work generically, keeping circular-reference handling and safe repr coercion for arbitrary metadata values instead of treating exceptions as a special nested schema.

For `ERROR` severity, the logger inspects the provided arguments and active exception state, then emits any available traceback at top-level `stack_trace`. Exception values passed via `error=` remain ordinary serialized metadata, so opaque or non-JSON-safe exception arguments no longer crash logging, but logs no longer emit nested-only traces or a Python-only `logger.exception(...)` helper.

The test coverage was updated to match the final behavior, including exception instances, `sys.exc_info()[0]`, self-referential and cyclic payloads, non-JSON-safe values, and the top-level stack trace shape.

## Testing

- Updated `tests/test_logger.py` to cover exception instances, exception types from `sys.exc_info()[0]`, cyclic/self-referential payloads, non-JSON-safe values, and top-level `stack_trace` behavior for `ERROR` logs.
- Ran `python3 -m pytest -q tests/test_logger.py`
