### PR TITLE
fix: preserve crashlytics options

### DIFF
--- a/src/firebase_functions/options.py
+++ b/src/firebase_functions/options.py
@@ -652,6 +652,23 @@ class FirebaseAlertOptions(EventHandlerOptions):
         )
 
 
+def _alert_options_to_firebase_alert_options(
+    options: EventHandlerOptions,
+    alert_type: str | AlertType,
+    app_id: str | None = None,
+) -> FirebaseAlertOptions:
+    option_values = {
+        field.name: getattr(options, field.name)
+        for field in _dataclasses.fields(options)
+        if field.name not in {"alert_type", "app_id"}
+    }
+    return FirebaseAlertOptions(
+        **option_values,
+        alert_type=alert_type,
+        app_id=app_id,
+    )
+
+
 @_dataclasses.dataclass(frozen=True, kw_only=True)
 class AppDistributionOptions(EventHandlerOptions):
     """
@@ -669,9 +686,10 @@ class AppDistributionOptions(EventHandlerOptions):
         **kwargs,
     ) -> _manifest.ManifestEndpoint:
         assert kwargs["alert_type"] is not None
-        return FirebaseAlertOptions(
-            alert_type=kwargs["alert_type"],
-            app_id=self.app_id,
+        return _alert_options_to_firebase_alert_options(
+            self,
+            kwargs["alert_type"],
+            self.app_id,
         )._endpoint(**kwargs)
 
 
@@ -692,9 +710,10 @@ class PerformanceOptions(EventHandlerOptions):
         **kwargs,
     ) -> _manifest.ManifestEndpoint:
         assert kwargs["alert_type"] is not None
-        return FirebaseAlertOptions(
-            alert_type=kwargs["alert_type"],
-            app_id=self.app_id,
+        return _alert_options_to_firebase_alert_options(
+            self,
+            kwargs["alert_type"],
+            self.app_id,
         )._endpoint(**kwargs)
 
 
@@ -715,9 +734,10 @@ class CrashlyticsOptions(EventHandlerOptions):
         **kwargs,
     ) -> _manifest.ManifestEndpoint:
         assert kwargs["alert_type"] is not None
-        return FirebaseAlertOptions(
-            alert_type=kwargs["alert_type"],
-            app_id=self.app_id,
+        return _alert_options_to_firebase_alert_options(
+            self,
+            kwargs["alert_type"],
+            self.app_id,
         )._endpoint(**kwargs)
 
 
@@ -733,8 +753,9 @@ class BillingOptions(EventHandlerOptions):
         **kwargs,
     ) -> _manifest.ManifestEndpoint:
         assert kwargs["alert_type"] is not None
-        return FirebaseAlertOptions(
-            alert_type=kwargs["alert_type"],
+        return _alert_options_to_firebase_alert_options(
+            self,
+            kwargs["alert_type"],
         )._endpoint(**kwargs)
 
 

--- a/src/firebase_functions/options.py
+++ b/src/firebase_functions/options.py
@@ -655,8 +655,8 @@ class FirebaseAlertOptions(EventHandlerOptions):
 def _alert_options_to_firebase_alert_options(
     options: EventHandlerOptions,
     alert_type: str | AlertType,
-    app_id: str | None = None,
 ) -> FirebaseAlertOptions:
+    app_id = getattr(options, "app_id", None)
     option_values = {
         field.name: getattr(options, field.name)
         for field in _dataclasses.fields(options)
@@ -689,7 +689,6 @@ class AppDistributionOptions(EventHandlerOptions):
         return _alert_options_to_firebase_alert_options(
             self,
             kwargs["alert_type"],
-            self.app_id,
         )._endpoint(**kwargs)
 
 
@@ -713,7 +712,6 @@ class PerformanceOptions(EventHandlerOptions):
         return _alert_options_to_firebase_alert_options(
             self,
             kwargs["alert_type"],
-            self.app_id,
         )._endpoint(**kwargs)
 
 
@@ -737,7 +735,6 @@ class CrashlyticsOptions(EventHandlerOptions):
         return _alert_options_to_firebase_alert_options(
             self,
             kwargs["alert_type"],
-            self.app_id,
         )._endpoint(**kwargs)
 
 

--- a/src/firebase_functions/options.py
+++ b/src/firebase_functions/options.py
@@ -657,10 +657,14 @@ def _alert_options_to_firebase_alert_options(
     alert_type: str | AlertType,
 ) -> FirebaseAlertOptions:
     app_id = getattr(options, "app_id", None)
+
+    # Restrict to fields supported by FirebaseAlertOptions
+    allowed_fields = {f.name for f in _dataclasses.fields(FirebaseAlertOptions)}
+
     option_values = {
         field.name: getattr(options, field.name)
         for field in _dataclasses.fields(options)
-        if field.name not in {"alert_type", "app_id"}
+        if field.name in allowed_fields and field.name not in {"alert_type", "app_id"}
     }
     return FirebaseAlertOptions(
         **option_values,

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -18,7 +18,12 @@ Options unit tests.
 from pytest import raises
 
 from firebase_functions import alerts_fn, https_fn, options, params
-from firebase_functions.alerts import app_distribution_fn, billing_fn, crashlytics_fn, performance_fn
+from firebase_functions.alerts import (
+    app_distribution_fn,
+    billing_fn,
+    crashlytics_fn,
+    performance_fn,
+)
 from firebase_functions.private.serving import functions_as_yaml, merge_required_apis
 
 # pylint: disable=protected-access

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -17,10 +17,13 @@ Options unit tests.
 
 from pytest import raises
 
-from firebase_functions import https_fn, options, params
+from firebase_functions import alerts_fn, https_fn, options, params
+from firebase_functions.alerts import app_distribution_fn, billing_fn, crashlytics_fn, performance_fn
 from firebase_functions.private.serving import functions_as_yaml, merge_required_apis
 
 # pylint: disable=protected-access
+
+ALERT_SECRET = params.SecretParam("GITLAB_PERSONAL_ACCESS_TOKEN")
 
 
 @https_fn.on_call()
@@ -196,3 +199,104 @@ def test_invoker_with_no_element_throws():
         AssertionError, match="HttpsOptions: Invalid option for invoker - must be a non-empty list."
     ):
         options.HttpsOptions(invoker=[])._endpoint(func_name="test")
+
+
+def _assert_alert_endpoint_options(endpoint, expected_alert_type, expect_app_id: str | None = None):
+    assert endpoint.region == ["europe-west1"]
+    assert endpoint.maxInstances == 1
+    assert endpoint.secretEnvironmentVariables == [{"key": "GITLAB_PERSONAL_ACCESS_TOKEN"}]
+    assert endpoint.eventTrigger["retry"] is True
+    assert endpoint.eventTrigger["eventFilters"]["alerttype"] == expected_alert_type
+    if expect_app_id is None:
+        assert "appid" not in endpoint.eventTrigger["eventFilters"]
+    else:
+        assert endpoint.eventTrigger["eventFilters"]["appid"] == expect_app_id
+
+
+def test_crashlytics_options_preserved_in_alert_endpoint():
+    @crashlytics_fn.on_new_fatal_issue_published(
+        secrets=[ALERT_SECRET],
+        region="europe-west1",
+        max_instances=1,
+        retry=True,
+        app_id="app-123",
+    )
+    def sample(_event):
+        return None
+
+    _assert_alert_endpoint_options(
+        sample.__firebase_endpoint__,
+        "crashlytics.newFatalIssue",
+        expect_app_id="app-123",
+    )
+
+
+def test_app_distribution_options_preserved_in_alert_endpoint():
+    @app_distribution_fn.on_new_tester_ios_device_published(
+        secrets=[ALERT_SECRET],
+        region="europe-west1",
+        max_instances=1,
+        retry=True,
+        app_id="app-123",
+    )
+    def sample(_event):
+        return None
+
+    _assert_alert_endpoint_options(
+        sample.__firebase_endpoint__,
+        "appDistribution.newTesterIosDevice",
+        expect_app_id="app-123",
+    )
+
+
+def test_performance_options_preserved_in_alert_endpoint():
+    @performance_fn.on_threshold_alert_published(
+        secrets=[ALERT_SECRET],
+        region="europe-west1",
+        max_instances=1,
+        retry=True,
+        app_id="app-123",
+    )
+    def sample(_event):
+        return None
+
+    _assert_alert_endpoint_options(
+        sample.__firebase_endpoint__,
+        "performance.threshold",
+        expect_app_id="app-123",
+    )
+
+
+def test_billing_options_preserved_in_alert_endpoint():
+    @billing_fn.on_plan_update_published(
+        secrets=[ALERT_SECRET],
+        region="europe-west1",
+        max_instances=1,
+        retry=True,
+    )
+    def sample(_event):
+        return None
+
+    _assert_alert_endpoint_options(
+        sample.__firebase_endpoint__,
+        "billing.planUpdate",
+    )
+
+
+def test_firebase_alert_options_preserved_in_alert_endpoint():
+    @alerts_fn.on_alert_published(
+        alert_type=alerts_fn.AlertType.CRASHLYTICS_NEW_FATAL_ISSUE,
+        secrets=[ALERT_SECRET],
+        region="europe-west1",
+        max_instances=1,
+        retry=True,
+        app_id="app-123",
+    )
+    def sample(_event):
+        return None
+
+    _assert_alert_endpoint_options(
+        sample.__firebase_endpoint__,
+        "crashlytics.newFatalIssue",
+        expect_app_id="app-123",
+    )


### PR DESCRIPTION
Fixes #265 

## Summary

Alert-based function decorators were reconstructing `FirebaseAlertOptions` with only `alert_type` and `app_id`, which dropped shared handler settings like `region`, `max_instances`, `retry`, and `secrets`. This change preserves the full option set when building alert endpoints and adds coverage across the alert wrappers that delegate to `FirebaseAlertOptions`.

## Problem/Root Cause

Issue #265 reports that Crashlytics alert handlers ignored configuration such as region, max instances, and secrets. The same pattern also applied to the other alert-specific option wrappers. In each `_endpoint()` implementation, the wrapper created a fresh `FirebaseAlertOptions` with just the alert identifiers, so the inherited `EventHandlerOptions` fields on the original options object never made it into the generated endpoint manifest.

## Solution/Changes

Add a shared helper that copies the dataclass fields from the original alert options object into a new `FirebaseAlertOptions`, while overriding only `alert_type` and `app_id` where needed. Update the App Distribution, Crashlytics, Performance, and Billing option wrappers to use that helper before generating the endpoint. Expand `tests/test_options.py` with endpoint assertions that verify shared options are preserved for each alert wrapper and for direct `alerts_fn.on_alert_published(...)` usage.

## Testing

- `uv run pytest tests/test_options.py`
