### PR TITLE
feat: add retry support for firestore, storage and realtime database

### DIFF
--- a/src/firebase_functions/options.py
+++ b/src/firebase_functions/options.py
@@ -905,7 +905,7 @@ class ScheduleOptions(RuntimeOptions):
 
 
 @_dataclasses.dataclass(frozen=True, kw_only=True)
-class StorageOptions(RuntimeOptions):
+class StorageOptions(EventHandlerOptions):
     """
     Options specific to Cloud Storage function types.
     Internal use only.
@@ -937,19 +937,19 @@ class StorageOptions(RuntimeOptions):
         }
         event_trigger = _manifest.EventTrigger(
             eventType=kwargs["event_type"],
-            retry=False,
+            retry=self.retry if self.retry is not None else False,
             eventFilters=event_filters,
         )
 
         kwargs_merged = {
-            **_dataclasses.asdict(super()._endpoint(**kwargs)),
+            **_dataclasses.asdict(RuntimeOptions._endpoint(self, **kwargs)),
             "eventTrigger": event_trigger,
         }
         return _manifest.ManifestEndpoint(**_typing.cast(dict, kwargs_merged))
 
 
 @_dataclasses.dataclass(frozen=True, kw_only=True)
-class DatabaseOptions(RuntimeOptions):
+class DatabaseOptions(EventHandlerOptions):
     """
     Options specific to Realtime Database function types.
     Internal use only.
@@ -990,13 +990,13 @@ class DatabaseOptions(RuntimeOptions):
 
         event_trigger = _manifest.EventTrigger(
             eventType=kwargs["event_type"],
-            retry=False,
+            retry=self.retry if self.retry is not None else False,
             eventFilters=event_filters,
             eventFilterPathPatterns=event_filters_path_patterns,
         )
 
         kwargs_merged = {
-            **_dataclasses.asdict(super()._endpoint(**kwargs)),
+            **_dataclasses.asdict(RuntimeOptions._endpoint(self, **kwargs)),
             "eventTrigger": event_trigger,
         }
         return _manifest.ManifestEndpoint(**_typing.cast(dict, kwargs_merged))
@@ -1055,7 +1055,7 @@ class BlockingOptions(RuntimeOptions):
 
 
 @_dataclasses.dataclass(frozen=True, kw_only=True)
-class FirestoreOptions(RuntimeOptions):
+class FirestoreOptions(EventHandlerOptions):
     """
     Options specific to Firestore function types.
     Internal use only.
@@ -1097,13 +1097,13 @@ class FirestoreOptions(RuntimeOptions):
             event_filters["document"] = event_filter_document
         event_trigger = _manifest.EventTrigger(
             eventType=kwargs["event_type"],
-            retry=False,
+            retry=self.retry if self.retry is not None else False,
             eventFilters=event_filters,
             eventFilterPathPatterns=event_filters_path_patterns,
         )
 
         kwargs_merged = {
-            **_dataclasses.asdict(super()._endpoint(**kwargs)),
+            **_dataclasses.asdict(RuntimeOptions._endpoint(self, **kwargs)),
             "eventTrigger": event_trigger,
         }
         return _manifest.ManifestEndpoint(**_typing.cast(dict, kwargs_merged))

--- a/src/firebase_functions/options.py
+++ b/src/firebase_functions/options.py
@@ -501,10 +501,16 @@ class EventHandlerOptions(RuntimeOptions):
         assert kwargs["event_filters"] is not None
         assert kwargs["event_type"] is not None
 
+        event_filters_path_patterns = kwargs.get("event_filters_path_patterns") or None
         event_trigger = _manifest.EventTrigger(
             eventType=kwargs["event_type"],
             retry=self.retry if self.retry is not None else False,
             eventFilters=kwargs["event_filters"],
+            **(
+                {"eventFilterPathPatterns": event_filters_path_patterns}
+                if event_filters_path_patterns is not None
+                else {}
+            ),
         )
 
         kwargs_merged = {
@@ -978,18 +984,11 @@ class DatabaseOptions(EventHandlerOptions):
         else:
             event_filters["instance"] = event_filter_instance
 
-        event_trigger = _manifest.EventTrigger(
-            eventType=kwargs["event_type"],
-            retry=self.retry if self.retry is not None else False,
-            eventFilters=event_filters,
-            eventFilterPathPatterns=event_filters_path_patterns,
+        return super()._endpoint(
+            **kwargs,
+            event_filters=event_filters,
+            event_filters_path_patterns=event_filters_path_patterns,
         )
-
-        kwargs_merged = {
-            **_dataclasses.asdict(RuntimeOptions._endpoint(self, **kwargs)),
-            "eventTrigger": event_trigger,
-        }
-        return _manifest.ManifestEndpoint(**_typing.cast(dict, kwargs_merged))
 
 
 @_dataclasses.dataclass(frozen=True, kw_only=True)
@@ -1085,18 +1084,11 @@ class FirestoreOptions(EventHandlerOptions):
             event_filters_path_patterns["document"] = event_filter_document
         else:
             event_filters["document"] = event_filter_document
-        event_trigger = _manifest.EventTrigger(
-            eventType=kwargs["event_type"],
-            retry=self.retry if self.retry is not None else False,
-            eventFilters=event_filters,
-            eventFilterPathPatterns=event_filters_path_patterns,
+        return super()._endpoint(
+            **kwargs,
+            event_filters=event_filters,
+            event_filters_path_patterns=event_filters_path_patterns,
         )
-
-        kwargs_merged = {
-            **_dataclasses.asdict(RuntimeOptions._endpoint(self, **kwargs)),
-            "eventTrigger": event_trigger,
-        }
-        return _manifest.ManifestEndpoint(**_typing.cast(dict, kwargs_merged))
 
 
 @_dataclasses.dataclass(frozen=True, kw_only=True)

--- a/src/firebase_functions/options.py
+++ b/src/firebase_functions/options.py
@@ -481,7 +481,6 @@ class TaskQueueOptions(RuntimeOptions):
         ]
 
 
-# TODO refactor Storage & Database options to use this base class.
 @_dataclasses.dataclass(frozen=True, kw_only=True)
 class EventHandlerOptions(RuntimeOptions):
     """
@@ -502,16 +501,20 @@ class EventHandlerOptions(RuntimeOptions):
         assert kwargs["event_type"] is not None
 
         event_filters_path_patterns = kwargs.get("event_filters_path_patterns") or None
-        event_trigger = _manifest.EventTrigger(
-            eventType=kwargs["event_type"],
-            retry=self.retry if self.retry is not None else False,
-            eventFilters=kwargs["event_filters"],
-            **(
-                {"eventFilterPathPatterns": event_filters_path_patterns}
-                if event_filters_path_patterns is not None
-                else {}
-            ),
-        )
+        retry = self.retry if self.retry is not None else False
+        if event_filters_path_patterns is not None:
+            event_trigger = _manifest.EventTrigger(
+                eventType=kwargs["event_type"],
+                retry=retry,
+                eventFilters=kwargs["event_filters"],
+                eventFilterPathPatterns=event_filters_path_patterns,
+            )
+        else:
+            event_trigger = _manifest.EventTrigger(
+                eventType=kwargs["event_type"],
+                retry=retry,
+                eventFilters=kwargs["event_filters"],
+            )
 
         kwargs_merged = {
             **_dataclasses.asdict(super()._endpoint(**kwargs)),

--- a/src/firebase_functions/options.py
+++ b/src/firebase_functions/options.py
@@ -935,17 +935,7 @@ class StorageOptions(EventHandlerOptions):
         event_filters: _typing.Any = {
             "bucket": bucket,
         }
-        event_trigger = _manifest.EventTrigger(
-            eventType=kwargs["event_type"],
-            retry=self.retry if self.retry is not None else False,
-            eventFilters=event_filters,
-        )
-
-        kwargs_merged = {
-            **_dataclasses.asdict(RuntimeOptions._endpoint(self, **kwargs)),
-            "eventTrigger": event_trigger,
-        }
-        return _manifest.ManifestEndpoint(**_typing.cast(dict, kwargs_merged))
+        return super()._endpoint(**kwargs, event_filters=event_filters)
 
 
 @_dataclasses.dataclass(frozen=True, kw_only=True)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -16,6 +16,24 @@ class TestDb(unittest.TestCase):
     Tests for the db module.
     """
 
+    def test_database_decorator_retry_option(self):
+        func = mock.Mock(__name__="example_func")
+        decorated_func = db_fn.on_value_written(reference="/items/{itemId}", retry=True)(func)
+
+        endpoint = decorated_func.__firebase_endpoint__
+
+        self.assertIsNotNone(endpoint.eventTrigger)
+        self.assertTrue(endpoint.eventTrigger["retry"])
+
+    def test_database_decorator_retry_defaults_false(self):
+        func = mock.Mock(__name__="example_func")
+        decorated_func = db_fn.on_value_written(reference="/items/{itemId}")(func)
+
+        endpoint = decorated_func.__firebase_endpoint__
+
+        self.assertIsNotNone(endpoint.eventTrigger)
+        self.assertFalse(endpoint.eventTrigger["retry"])
+
     def test_calls_init_function(self):
         hello = None
 

--- a/tests/test_firestore_fn.py
+++ b/tests/test_firestore_fn.py
@@ -18,6 +18,33 @@ class TestFirestore(TestCase):
     firestore_fn tests.
     """
 
+    def test_firestore_decorator_retry_option(self):
+        with patch.dict("sys.modules", mocked_modules):
+            from firebase_functions import firestore_fn
+
+            func = Mock(__name__="example_func")
+            decorated_func = firestore_fn.on_document_created(
+                document="/foo/{bar}",
+                retry=True,
+            )(func)
+
+            endpoint = decorated_func.__firebase_endpoint__
+
+            self.assertIsNotNone(endpoint.eventTrigger)
+            self.assertTrue(endpoint.eventTrigger["retry"])
+
+    def test_firestore_decorator_retry_defaults_false(self):
+        with patch.dict("sys.modules", mocked_modules):
+            from firebase_functions import firestore_fn
+
+            func = Mock(__name__="example_func")
+            decorated_func = firestore_fn.on_document_created(document="/foo/{bar}")(func)
+
+            endpoint = decorated_func.__firebase_endpoint__
+
+            self.assertIsNotNone(endpoint.eventTrigger)
+            self.assertFalse(endpoint.eventTrigger["retry"])
+
     def test_firestore_endpoint_handler_calls_function_with_correct_args(self):
         with patch.dict("sys.modules", mocked_modules):
             from cloudevents.http import CloudEvent

--- a/tests/test_firestore_fn.py
+++ b/tests/test_firestore_fn.py
@@ -45,6 +45,18 @@ class TestFirestore(TestCase):
             self.assertIsNotNone(endpoint.eventTrigger)
             self.assertFalse(endpoint.eventTrigger["retry"])
 
+    def test_firestore_decorator_omits_empty_path_patterns(self):
+        with patch.dict("sys.modules", mocked_modules):
+            from firebase_functions import firestore_fn
+
+            func = Mock(__name__="example_func")
+            decorated_func = firestore_fn.on_document_created(document="/foo/bar")(func)
+
+            endpoint = decorated_func.__firebase_endpoint__
+
+            self.assertIsNotNone(endpoint.eventTrigger)
+            self.assertNotIn("eventFilterPathPatterns", endpoint.eventTrigger)
+
     def test_firestore_endpoint_handler_calls_function_with_correct_args(self):
         with patch.dict("sys.modules", mocked_modules):
             from cloudevents.http import CloudEvent

--- a/tests/test_storage_fn.py
+++ b/tests/test_storage_fn.py
@@ -15,6 +15,24 @@ class TestStorage(unittest.TestCase):
     Storage function tests.
     """
 
+    def test_storage_decorator_retry_option(self):
+        func = Mock(__name__="example_func")
+        decorated_func = storage_fn.on_object_finalized(bucket="bucket", retry=True)(func)
+
+        endpoint = decorated_func.__firebase_endpoint__
+
+        self.assertIsNotNone(endpoint.eventTrigger)
+        self.assertTrue(endpoint.eventTrigger["retry"])
+
+    def test_storage_decorator_retry_defaults_false(self):
+        func = Mock(__name__="example_func")
+        decorated_func = storage_fn.on_object_finalized(bucket="bucket")(func)
+
+        endpoint = decorated_func.__firebase_endpoint__
+
+        self.assertIsNotNone(endpoint.eventTrigger)
+        self.assertFalse(endpoint.eventTrigger["retry"])
+
     def test_calls_init(self):
         hello = None
 


### PR DESCRIPTION
Fixes #165 

This PR maintains parity between the Python and JavaScript SDKs by adding retry support for Storage, Firestore, and Realtime Database.